### PR TITLE
support full-perfect-observations for Discrete-time systems

### DIFF
--- a/dsx/observations.py
+++ b/dsx/observations.py
@@ -24,3 +24,12 @@ class LinearGaussianObservation(ObservationModel):
 
     def __call__(self, x, u, t):
         return dist.MultivariateNormal(loc=jnp.dot(self.H, x), covariance_matrix=self.R)
+
+
+class DiracIdentityObservation(ObservationModel):
+    """
+    y_t | x_t ~ DiracDelta(x_t)
+    """
+
+    def __call__(self, x, u, t):
+        return dist.Delta(x)

--- a/dsx/simulators.py
+++ b/dsx/simulators.py
@@ -4,6 +4,7 @@ import dataclasses
 from dsx.handlers import BaseSimulator
 from dsx.ops import States, Context
 from dsx.dynamical_models import ContinuousTimeStateEvolution, DynamicalModel
+from dsx.observations import DiracIdentityObservation
 from dsx.utils import (
     dsx_to_cd_dynamax,
     _get_controls,
@@ -185,8 +186,35 @@ class DiscreteTimeSimulator(BaseSimulator):
 
         T = len(obs_times)
 
+        # DiracIdentityObservation with observed values: y_t = x_t, so we use plating
+        # instead of scan. state_evolution returns a dist; call it with batched inputs.
+        if isinstance(dynamics.observation_model, DiracIdentityObservation) and (
+            obs_values is not None
+        ):
+            numpyro.sample("x_0", dynamics.initial_condition, obs=obs_values[0])
+            numpyro.deterministic("y_0", obs_values[0])
+
+            x_prev = obs_values[:-1]
+            x_next = obs_values[1:]
+            u_prev = ctrl_values[:-1] if ctrl_values is not None else None
+            t_now = obs_times[:-1]
+            t_next = obs_times[1:]
+
+            with numpyro.plate("time", T - 1):
+                trans = dynamics.state_evolution(
+                    x=x_prev, u=u_prev, t_now=t_now, t_next=t_next
+                )
+                numpyro.sample("x_next", trans, obs=x_next)
+
+            return {
+                "times": obs_times,
+                "states": obs_values,
+                "observations": obs_values,
+            }
+
+        # Default: scan over time
         # Sample initial state
-        x_prev = numpyro.sample("x_0", dynamics.initial_condition)
+        x_prev = numpyro.sample("x_0", dynamics.initial_condition)  # type: ignore[assignment]
 
         # sample initial observation
         u_0 = _get_val_or_None(ctrl_values, 0)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,6 +16,7 @@ from dsx.filters import (
 from tests.models import (
     discrete_time_l63_model,
     hmm_model,
+    stochastic_volatility,
     continuous_time_stochastic_l63_model,
     continuous_time_LTI_gaussian,
     continuous_time_deterministic_l63_model,
@@ -335,6 +336,50 @@ def data_conditioned_continuous_time_deterministic_l63(request):
                 return continuous_time_deterministic_l63_model()
 
     return data_conditioned_model, true_params, synthetic, use_controls
+
+
+@pytest.fixture(params=[False, True])
+def data_conditioned_stochastic_volatility(request):
+    """Stochastic volatility with DiscreteTimeSimulator; no controls.
+    params: identity_observation (False = noisily observed, True = DiracIdentityObservation)."""
+    identity_observation = request.param
+    rng_key = jr.PRNGKey(0)
+    data_init_key, _mcmc_key, _posterior_pred_key, _ctrl_key = jr.split(rng_key, 4)
+
+    true_phi = 0.9
+    obs_times = jnp.arange(start=0.0, stop=100.0, step=1.0)
+    control_trajectory = Trajectory()
+
+    def model():
+        return stochastic_volatility(identity_observation=identity_observation)
+
+    true_params = {"phi": jnp.array(true_phi)}
+    predictive = Predictive(
+        model,
+        params=true_params,
+        num_samples=1,
+        exclude_deterministic=False,
+    )
+
+    context = Context(
+        observations=Trajectory(times=obs_times), controls=control_trajectory
+    )
+    with DiscreteTimeSimulator():
+        with Condition(context):
+            synthetic = predictive(data_init_key)
+
+    obs_values = synthetic["observations"].squeeze(0)
+    observation_trajectory = Trajectory(times=obs_times, values=obs_values)
+
+    def data_conditioned_model():
+        context = Context(
+            observations=observation_trajectory, controls=control_trajectory
+        )
+        with DiscreteTimeSimulator():
+            with Condition(context):
+                return stochastic_volatility(identity_observation=identity_observation)
+
+    return data_conditioned_model, true_params, synthetic, identity_observation
 
 
 @pytest.fixture(params=[False, True])

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,8 +3,11 @@ import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 
-from dsx.dynamical_models import DynamicalModel, ContinuousTimeStateEvolution
-from dsx.observations import LinearGaussianObservation
+from dsx.dynamical_models import (
+    DynamicalModel,
+    ContinuousTimeStateEvolution,
+)
+from dsx.observations import LinearGaussianObservation, DiracIdentityObservation
 import dsx
 
 
@@ -178,6 +181,36 @@ def continuous_time_LTI_gaussian():
         observation_model=LinearGaussianObservation(
             H=jnp.array([[0.0, 1.0]]), R=jnp.array([[1.0**2]])
         ),
+    )
+    return dsx.sample_ds("f", dynamics)
+
+
+def stochastic_volatility(identity_observation: bool = False):
+    """Discrete-time stochastic volatility: log-variance follows AR(1).
+    One unknown parameter: phi (persistence). No controls.
+    If identity_observation=True, y_t = x_t (DiracIdentityObservation); else noisily observed."""
+    phi = numpyro.sample("phi", dist.Uniform(0.0, 1.0))  # type: ignore[arg-type]
+    sigma_eta = 0.5  # fixed vol-of-vol
+
+    initial_condition = dist.Normal(0.0, 1.0)
+
+    def state_evolution(x, u, t_now, t_next):
+        return dist.Normal(phi * x, sigma_eta)
+
+    if identity_observation:
+        observation_model = DiracIdentityObservation()
+    else:
+
+        def observation_model(x, u, t):  # type: ignore[misc]
+            return dist.Normal(0.0, jnp.exp(x / 2.0))
+
+    dynamics = DynamicalModel(
+        state_dim=1,
+        observation_dim=1,
+        control_dim=0,
+        initial_condition=initial_condition,
+        state_evolution=state_evolution,
+        observation_model=observation_model,
     )
     return dsx.sample_ds("f", dynamics)
 

--- a/tests/test_mcmc_smokes.py
+++ b/tests/test_mcmc_smokes.py
@@ -11,6 +11,7 @@ from numpyro.infer import MCMC, NUTS, BarkerMH
 from tests.fixtures import (
     data_conditioned_hmm,  # noqa: F401
     data_conditioned_discrete_time_l63,  # noqa: F401
+    data_conditioned_stochastic_volatility,  # noqa: F401
     data_conditioned_continuous_time_l63_dpf,  # noqa: F401
     data_conditioned_continuous_time_lti_gaussian,  # noqa: F401
     data_conditioned_continuous_time_lti_gaussian_dpf,  # noqa: F401
@@ -46,6 +47,19 @@ def test_discrete_time_l63_mcmc_smoke(data_conditioned_discrete_time_l63):  # no
     mcmc.run(mcmc_key)
     posterior_samples = mcmc.get_samples()
     assert "rho" in posterior_samples
+
+
+def test_stochastic_volatility_mcmc_smoke(data_conditioned_stochastic_volatility):  # noqa: F811
+    mcmc_key = jr.PRNGKey(0)
+    data_conditioned_model, true_params, synthetic, _ = (
+        data_conditioned_stochastic_volatility
+    )
+    mcmc = MCMC(
+        NUTS(data_conditioned_model), num_samples=NUM_SAMPLES, num_warmup=NUM_WARMUP
+    )
+    mcmc.run(mcmc_key)
+    posterior_samples = mcmc.get_samples()
+    assert "phi" in posterior_samples
 
 
 def test_continuous_time_stochastic_l63_mcmc_smoke(

--- a/tests/test_science/test_stochastic_volatility_mcmc.py
+++ b/tests/test_science/test_stochastic_volatility_mcmc.py
@@ -1,0 +1,69 @@
+import jax.numpy as jnp
+import jax.random as jr
+
+import arviz as az
+from numpyro.infer import MCMC, NUTS
+import pytest
+
+from tests.fixtures import data_conditioned_stochastic_volatility  # noqa: F401
+from tests.test_utils import get_output_dir
+
+SAVE_FIG = True
+
+
+@pytest.mark.parametrize("num_samples", [250])
+def test_mcmc_inference(data_conditioned_stochastic_volatility, num_samples):  # noqa: F811
+    (
+        data_conditioned_model,
+        true_params,
+        synthetic,
+        _use_controls,
+    ) = data_conditioned_stochastic_volatility
+
+    output_dir_name = "test_stochastic_volatility_mcmc"
+    OUTPUT_DIR = get_output_dir(output_dir_name)
+
+    obs_times = synthetic["times"]
+
+    if SAVE_FIG and OUTPUT_DIR is not None:
+        import matplotlib.pyplot as plt
+
+        states_1d = jnp.squeeze(synthetic["states"])
+        obs_1d = jnp.squeeze(synthetic["observations"])
+        times_1d = jnp.squeeze(obs_times)
+        plt.plot(times_1d, states_1d, label="log-variance")
+        plt.plot(times_1d, obs_1d, label="observations", linestyle="--")
+        plt.legend()
+        plt.savefig(OUTPUT_DIR / "data_generation.png", dpi=150, bbox_inches="tight")
+        plt.close()
+
+    mcmc_key = jr.PRNGKey(0)
+    nuts_kernel = NUTS(data_conditioned_model)
+    mcmc = MCMC(nuts_kernel, num_samples=num_samples, num_warmup=num_samples)
+    mcmc.run(mcmc_key)
+
+    posterior_samples = mcmc.get_samples()
+
+    assert "phi" in posterior_samples
+    posterior_phi = posterior_samples["phi"]
+    assert len(posterior_phi) == num_samples
+    assert not jnp.isnan(posterior_phi).any()
+    assert not jnp.isinf(posterior_phi).any()
+
+    if SAVE_FIG and OUTPUT_DIR is not None:
+        import matplotlib.pyplot as plt
+
+        az.plot_posterior(
+            posterior_phi, hdi_prob=0.95, ref_val=true_params["phi"].item()
+        )
+        plt.savefig(OUTPUT_DIR / "posterior_phi.png", dpi=150, bbox_inches="tight")
+        plt.close()
+
+    assert jnp.abs(posterior_phi.mean() - true_params["phi"]) < 0.3
+
+    hdi_data = az.hdi(posterior_phi, hdi_prob=0.95)
+    hdi_min = hdi_data["x"].sel(hdi="lower").item()
+    hdi_max = hdi_data["x"].sel(hdi="higher").item()
+    assert hdi_min <= true_params["phi"] <= hdi_max, (
+        f"True phi {true_params['phi']} not in HDI {hdi_min}, {hdi_max}"
+    )


### PR DESCRIPTION
- new DiracIdentityObservation in `observations.py`
- added a plate-based block to `DiscreteTimeSimulator` that checks for DiracIdentityObservation
---The point is to do efficient (decoupled) inference since y_t = x_t here.
- added stochastic volatility test (with parameter for perfect OR noisy observations)