### PR TITLE
Fix resampling

### DIFF
--- a/dynestyx/cuthbert_patches/multinomial_resampling.py
+++ b/dynestyx/cuthbert_patches/multinomial_resampling.py
@@ -19,7 +19,9 @@ from cuthbertlib.resampling.protocols import (
 )
 from cuthbertlib.resampling.utils import _inverse_cdf_default
 from cuthbertlib.types import Array, ArrayLike
+from jax import numpy as jnp
 from jax import random
+from jax.scipy.special import logsumexp
 
 
 @partial(resampling_decorator, name="Multinomial", desc=_DESCRIPTION)
@@ -37,7 +39,8 @@ def resampling(key: Array, logits: ArrayLike, n: int) -> Array:
     # In cuthbert, this may use a jax.pure_callback,
     # which is incompatible with gradient-based sampling methods.
     # Here, we use the default resampling function, which is a pure jax function.
-    idx = _inverse_cdf_default(sorted_uniforms, logits)
+    weights = jnp.exp(jnp.asarray(logits) - logsumexp(logits))
+    idx = _inverse_cdf_default(sorted_uniforms, weights)
     return random.permutation(key_shuffle, idx)
 
 

--- a/dynestyx/cuthbert_patches/systematic_resampling.py
+++ b/dynestyx/cuthbert_patches/systematic_resampling.py
@@ -23,12 +23,14 @@ from cuthbertlib.resampling.utils import _inverse_cdf_default
 from cuthbertlib.types import Array, ArrayLike
 from jax import numpy as jnp
 from jax import random
+from jax.scipy.special import logsumexp
 
 
 @partial(resampling_decorator, name="Systematic", desc=_DESCRIPTION)
 def resampling(key: Array, logits: ArrayLike, n: int) -> Array:
     us = (random.uniform(key, ()) + jnp.arange(n)) / n
-    return _inverse_cdf_default(us, logits)
+    weights = jnp.exp(jnp.asarray(logits) - logsumexp(logits))
+    return _inverse_cdf_default(us, weights)
 
 
 conditional_resampling = conditional_resampling_original


### PR DESCRIPTION
Resampling currently does not normalize logits into weights, which the inverse cdf function does not handle. This introduces a fix mirroring the cuthbert code for multinomial and systematic resampling.