### PR TITLE
Revert to `HandlesSelf`

### DIFF
--- a/dynestyx/filters.py
+++ b/dynestyx/filters.py
@@ -6,7 +6,7 @@ import numpyro
 from cd_dynamax import ContDiscreteNonlinearGaussianSSM, ContDiscreteNonlinearSSM
 
 from dynestyx.dynamical_models import Context, DynamicalModel
-from dynestyx.handlers import BaseCDDynamaxLogFactorAdder, FunctionOfTime, handles
+from dynestyx.handlers import BaseCDDynamaxLogFactorAdder
 from dynestyx.hmm_filter import hmm_filter, hmm_log_components
 from dynestyx.inference.cd_dynamax.continuous_time_filters import (
     _CONTINUOUS_FILTER_TYPES,
@@ -22,7 +22,7 @@ type SSMType = ContDiscreteNonlinearGaussianSSM | ContDiscreteNonlinearSSM
 
 
 @dataclasses.dataclass
-class FilterBasedMarginalLogLikelihoodObjIntp(BaseCDDynamaxLogFactorAdder):
+class FilterBasedMarginalLogLikelihood(BaseCDDynamaxLogFactorAdder):
     """
     Object for filtering a dynamical model, and adding the resulting marginal log likelihood as a numpyro factor.
 
@@ -105,15 +105,8 @@ class FilterBasedMarginalLogLikelihoodObjIntp(BaseCDDynamaxLogFactorAdder):
             )
 
 
-@handles(FilterBasedMarginalLogLikelihoodObjIntp)
-def FilterBasedMarginalLogLikelihood(  # type: ignore[empty-body]
-    name: str, dynamics: DynamicalModel, context: Context | None = None
-) -> FunctionOfTime:
-    pass
-
-
 @dataclasses.dataclass
-class FilterBasedHMMMarginalLogLikelihoodObjIntp(BaseCDDynamaxLogFactorAdder):
+class FilterBasedHMMMarginalLogLikelihood(BaseCDDynamaxLogFactorAdder):
     """
     Exact HMM marginal log-likelihood via forward filtering.
 
@@ -182,10 +175,3 @@ class FilterBasedHMMMarginalLogLikelihoodObjIntp(BaseCDDynamaxLogFactorAdder):
                 f"{name}_filtered_states",
                 jnp.exp(log_filt_seq),  # (T, K)
             )
-
-
-@handles(FilterBasedHMMMarginalLogLikelihoodObjIntp)
-def FilterBasedHMMMarginalLogLikelihood(  # type: ignore[empty-body]
-    name: str, dynamics: DynamicalModel, context: Context | None = None
-) -> FunctionOfTime:
-    pass

--- a/dynestyx/handlers.py
+++ b/dynestyx/handlers.py
@@ -1,10 +1,7 @@
 # handlers.py
 """Handlers for dsx operations using Interpretation-based style."""
 
-from collections.abc import Callable
-from contextlib import AbstractContextManager, contextmanager
-from functools import wraps
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import numpyro
 from effectful.ops.semantics import fwd, handler
@@ -30,34 +27,27 @@ def sample(
     raise NotHandled()
 
 
-def handles[T](
-    cls: type[T],
-) -> Callable[[Callable[..., Any]], Callable[..., AbstractContextManager[Any]]]:
-    """
-    @handles(SomeClass)
-    def f(...): ...
+class HandlesSelf:
+    """Mixin class that allows an object to act as an interpretation and its own handler.
 
-    Then: with f(*args, **kwargs): ...
-    will do: handle(SomeClass(*args, **kwargs))
+    Note: this is unidiomatic for `effectful` code, but it simplifies our documentation and development process.
+
+    In particular, it is not straightforward to define a decorator that automates interpretation handling whilst
+    keeping IDE-friendly docstrings.
     """
 
-    def decorator(fn: Callable[..., Any]) -> Callable[..., AbstractContextManager[Any]]:
-        @wraps(fn)
-        def wrapped(*args: Any, **kwargs: Any) -> AbstractContextManager[Any]:
-            @contextmanager
-            def cm():
-                obj = cls(*args, **kwargs)
-                with handler(obj):
-                    yield
+    _cm = None
 
-            return cm()
+    def __enter__(self):
+        self._cm = handler(self)
+        self._cm.__enter__()
+        return self._cm
 
-        return wrapped
-
-    return decorator
+    def __exit__(self, exc_type, exc, tb):
+        return self._cm.__exit__(exc_type, exc, tb)
 
 
-class DiscretizerObjIntp(ObjectInterpretation):
+class Discretizer(ObjectInterpretation, HandlesSelf):
     """
     Discretize a continuous-time state evolution to a discrete-time state evolution.
     Args:
@@ -89,14 +79,7 @@ class DiscretizerObjIntp(ObjectInterpretation):
         return fwd(name, dynamics, context)
 
 
-@handles(DiscretizerObjIntp)
-def Discretizer(  # type: ignore[empty-body]
-    name: str, dynamics: DynamicalModel, context: Context | None = None
-) -> FunctionOfTime:
-    pass
-
-
-class ConditionObjIntp(ObjectInterpretation):
+class Condition(ObjectInterpretation, HandlesSelf):
     def __init__(self, context: Context):
         super().__init__()
         self.context = context
@@ -113,14 +96,7 @@ class ConditionObjIntp(ObjectInterpretation):
         return fwd(name, dynamics, site_ctx)
 
 
-@handles(ConditionObjIntp)
-def Condition(  # type: ignore[empty-body]
-    name: str, dynamics: DynamicalModel, context: Context | None = None
-) -> FunctionOfTime:
-    pass
-
-
-class BaseSimulatorObjIntp(ObjectInterpretation):
+class BaseSimulator(ObjectInterpretation, HandlesSelf):
     """Base class for simulators/unrollers.
 
     Concrete simulators implement `simulate(context, dynamics)` and optionally
@@ -170,7 +146,7 @@ class BaseSimulatorObjIntp(ObjectInterpretation):
         raise NotImplementedError()
 
 
-class BaseCDDynamaxLogFactorAdder(ObjectInterpretation):
+class BaseCDDynamaxLogFactorAdder(ObjectInterpretation, HandlesSelf):
     @implements(sample)
     def _sample_ds(
         self,

--- a/dynestyx/simulators.py
+++ b/dynestyx/simulators.py
@@ -13,10 +13,9 @@ from dynestyx.dynamical_models import (
     ContinuousTimeStateEvolution,
     DiscreteTimeStateEvolution,
     DynamicalModel,
-    FunctionOfTime,
     State,
 )
-from dynestyx.handlers import BaseSimulatorObjIntp, handles
+from dynestyx.handlers import BaseSimulator
 from dynestyx.inference.cd_dynamax.utils import dsx_to_cd_dynamax
 from dynestyx.observations import DiracIdentityObservation
 from dynestyx.utils import (
@@ -28,7 +27,7 @@ from dynestyx.utils import (
 type SSMType = ContDiscreteNonlinearGaussianSSM | ContDiscreteNonlinearSSM
 
 
-class SDESimulatorObjIntp(BaseSimulatorObjIntp):
+class SDESimulator(BaseSimulator):
     """Simulator that works with ContinuousTimeStateEvolution with stochastic dynamics."""
 
     def __init__(
@@ -158,21 +157,8 @@ class SDESimulatorObjIntp(BaseSimulatorObjIntp):
                 )
 
 
-@handles(SDESimulatorObjIntp)
-def SDESimulator(  # type: ignore[empty-body]
-    key: Array,
-    solver: dfx.AbstractSolver = dfx.Heun(),
-    stepsize_controller: dfx.AbstractStepSizeController = dfx.ConstantStepSize(),
-    adjoint: dfx.AbstractAdjoint = dfx.RecursiveCheckpointAdjoint(),
-    dt0: float = 0.01,
-    tol_vbt: float = 1e-1,  # tolerance for virtual brownian tree
-    max_steps: int = int(1e5),
-):
-    pass
-
-
 @dataclasses.dataclass
-class DiscreteTimeSimulatorObjIntp(BaseSimulatorObjIntp):
+class DiscreteTimeSimulator(BaseSimulator):
     """Simulator for discrete-time dynamical models.
 
     Assumes we have ic, transition, and observation distributions,
@@ -317,15 +303,8 @@ class DiscreteTimeSimulatorObjIntp(BaseSimulatorObjIntp):
         return {"times": obs_times, "states": states, "observations": observations}
 
 
-@handles(DiscreteTimeSimulatorObjIntp)
-def DiscreteTimeSimulator(  # type: ignore[empty-body]
-    *args, **kwargs
-):
-    pass
-
-
 @dataclasses.dataclass
-class ODESimulatorObjIntp(BaseSimulatorObjIntp):
+class ODESimulator(BaseSimulator):
     """Simulator for continuous-time deterministic (ODE) dynamical models.
 
     Assumes we have ic, transition, and observation distributions,
@@ -429,18 +408,7 @@ class ODESimulatorObjIntp(BaseSimulatorObjIntp):
         return {"times": obs_times, "states": x_sol, "observations": observations}
 
 
-@handles(ODESimulatorObjIntp)
-def ODESimulator(  # type: ignore[empty-body]
-    solver: dfx.AbstractSolver = dfx.Tsit5(),
-    adjoint: dfx.AbstractAdjoint = dfx.RecursiveCheckpointAdjoint(),
-    stepsize_controller: dfx.AbstractStepSizeController = dfx.ConstantStepSize(),
-    dt0: float = 0.01,
-    max_steps: int = 10_000,
-):
-    pass
-
-
-class SimulatorObjIntp(BaseSimulatorObjIntp):
+class Simulator(BaseSimulator):
     """Simulator for dynamical models.
 
     This is a wrapper class that selects the appropriate simulator based on the type of dynamical model.
@@ -465,11 +433,11 @@ class SimulatorObjIntp(BaseSimulatorObjIntp):
                     dynamics.state_evolution.diffusion_coefficient is None
                     or dynamics.state_evolution.diffusion_covariance is None
                 ):
-                    self.simulator = ODESimulatorObjIntp(*self.args, **self.kwargs)
+                    self.simulator = ODESimulator(*self.args, **self.kwargs)
                 else:
-                    self.simulator = SDESimulatorObjIntp(*self.args, **self.kwargs)
+                    self.simulator = SDESimulator(*self.args, **self.kwargs)
             elif isinstance(dynamics.state_evolution, DiscreteTimeStateEvolution):
-                self.simulator = DiscreteTimeSimulatorObjIntp(*self.args, **self.kwargs)
+                self.simulator = DiscreteTimeSimulator(*self.args, **self.kwargs)
             else:
                 raise ValueError(
                     f"Unsupported state evolution type: {type(dynamics.state_evolution)}."
@@ -477,10 +445,3 @@ class SimulatorObjIntp(BaseSimulatorObjIntp):
                 )
 
         return self.simulator.add_solved_sites(name, dynamics, context)
-
-
-@handles(SimulatorObjIntp)
-def Simulator(  # type: ignore[empty-body]
-    name: str, dynamics: DynamicalModel, context: Context | None = None
-) -> FunctionOfTime:
-    pass


### PR DESCRIPTION
The HandlesSelf mixin pattern is unidiomatic for `effectful` code, so we moved to separate interpretation/handler objects. This unfortuately caused some issues with documentation: for documentation to render in an editor like VS code, the args would have to be exactly copy-pasted from the interpretation to the handled version, and all documentation would have to live in the handled version. This is somewhat fragile, and the documentation is somewhat direct. Therefore, it seems for our purposes, the unidiomatic code is a beneficial tradeoff for code readability and usability.