### PR TITLE
run CI tests with 0.01x particles for speeeed

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,4 +12,4 @@ export TEST_OUTPUT_MASTER_DIR="$MASTER_OUTPUT_DIR"
 
 echo "Master output directory: $MASTER_OUTPUT_DIR"
 
-pytest tests/ -n auto --ignore=tests/test_science
+DYNESTYX_PF_PARTICLES_SCALE=0.01 pytest tests/ -n auto --ignore=tests/test_science

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,13 @@
+import os
+
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
+
+# Scale factor for particle filter particle counts.
+# Set DYNESTYX_PF_PARTICLES_SCALE=0.01 in CI for ~100x faster PF-based tests.
+_PF_PARTICLES_SCALE = float(os.environ.get("DYNESTYX_PF_PARTICLES_SCALE", "1.0"))
+
 from numpyro.infer import Predictive
 
 from dynestyx.discretizers import Discretizer
@@ -263,7 +270,9 @@ def data_conditioned_discrete_time_l63_filter_pf(request):
 
     # Build conditioned model
     def data_conditioned_model():
-        with Filter(filter_config=PFConfig(n_particles=3_000)):
+        with Filter(
+            filter_config=PFConfig(n_particles=int(3_000 * _PF_PARTICLES_SCALE))
+        ):
             return discrete_time_l63_model(
                 obs_times=obs_times,
                 obs_values=obs_values,
@@ -394,7 +403,11 @@ def data_conditioned_continuous_time_l63_dpf(request):
     # Build conditioned model
     # ---------------------------------------------------------
     def data_conditioned_model():
-        with Filter(filter_config=ContinuousTimeDPFConfig(n_particles=1_000)):
+        with Filter(
+            filter_config=ContinuousTimeDPFConfig(
+                n_particles=int(1_000 * _PF_PARTICLES_SCALE)
+            )
+        ):
             return continuous_time_stochastic_l63_model(
                 obs_times=obs_times,
                 obs_values=obs_values,
@@ -658,7 +671,11 @@ def data_conditioned_continuous_time_lti_gaussian_dpf(request):
     obs_values = synthetic["observations"].squeeze(0)
 
     def data_conditioned_model():
-        with Filter(filter_config=ContinuousTimeDPFConfig(n_particles=2_500)):
+        with Filter(
+            filter_config=ContinuousTimeDPFConfig(
+                n_particles=int(2_500 * _PF_PARTICLES_SCALE)
+            )
+        ):
             return continuous_time_LTI_gaussian(
                 obs_times=obs_times,
                 obs_values=obs_values,
@@ -1161,7 +1178,9 @@ def data_conditioned_continuous_time_lti_simplified_science(request):
     config = (
         ContinuousTimeKFConfig()
         if filter_type == "kf"
-        else ContinuousTimeDPFConfig(n_particles=2_000)
+        else ContinuousTimeDPFConfig(
+            n_particles=2_000,
+        )
     )
 
     def data_conditioned_model():

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,7 +5,14 @@ import jax.random as jr
 import pytest
 
 # Scale factor for particle filter particle counts.
+# Set DYNESTYX_PF_PARTICLES_SCALE=0.1 in CI for ~10x faster PF-based tests.
 _PF_PARTICLES_SCALE = float(os.environ.get("DYNESTYX_PF_PARTICLES_SCALE", "1.0"))
+_MIN_PARTICLES = 10
+
+
+def _n_particles(base: int) -> int:
+    return max(_MIN_PARTICLES, int(base * _PF_PARTICLES_SCALE))
+
 
 from numpyro.infer import Predictive
 
@@ -269,9 +276,7 @@ def data_conditioned_discrete_time_l63_filter_pf(request):
 
     # Build conditioned model
     def data_conditioned_model():
-        with Filter(
-            filter_config=PFConfig(n_particles=int(3_000 * _PF_PARTICLES_SCALE))
-        ):
+        with Filter(filter_config=PFConfig(n_particles=_n_particles(3_000))):
             return discrete_time_l63_model(
                 obs_times=obs_times,
                 obs_values=obs_values,
@@ -403,9 +408,7 @@ def data_conditioned_continuous_time_l63_dpf(request):
     # ---------------------------------------------------------
     def data_conditioned_model():
         with Filter(
-            filter_config=ContinuousTimeDPFConfig(
-                n_particles=int(1_000 * _PF_PARTICLES_SCALE)
-            )
+            filter_config=ContinuousTimeDPFConfig(n_particles=_n_particles(1_000))
         ):
             return continuous_time_stochastic_l63_model(
                 obs_times=obs_times,
@@ -671,9 +674,7 @@ def data_conditioned_continuous_time_lti_gaussian_dpf(request):
 
     def data_conditioned_model():
         with Filter(
-            filter_config=ContinuousTimeDPFConfig(
-                n_particles=int(2_500 * _PF_PARTICLES_SCALE)
-            )
+            filter_config=ContinuousTimeDPFConfig(n_particles=_n_particles(2_500))
         ):
             return continuous_time_LTI_gaussian(
                 obs_times=obs_times,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,7 +5,6 @@ import jax.random as jr
 import pytest
 
 # Scale factor for particle filter particle counts.
-# Set DYNESTYX_PF_PARTICLES_SCALE=0.1 in CI for ~10x faster PF-based tests.
 _PF_PARTICLES_SCALE = float(os.environ.get("DYNESTYX_PF_PARTICLES_SCALE", "1.0"))
 _MIN_PARTICLES = 10
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,7 +5,6 @@ import jax.random as jr
 import pytest
 
 # Scale factor for particle filter particle counts.
-# Set DYNESTYX_PF_PARTICLES_SCALE=0.01 in CI for ~100x faster PF-based tests.
 _PF_PARTICLES_SCALE = float(os.environ.get("DYNESTYX_PF_PARTICLES_SCALE", "1.0"))
 
 from numpyro.infer import Predictive

--- a/tests/test_mcmc_smokes.py
+++ b/tests/test_mcmc_smokes.py
@@ -158,7 +158,9 @@ def test_continuous_time_stochastic_l63_dpf_mcmc_smoke(
     data_conditioned_model, true_params, synthetic, _ = (
         data_conditioned_continuous_time_l63_dpf
     )
-    mcmc = MCMC(BarkerMH(data_conditioned_model), num_samples=10, num_warmup=10)
+    mcmc = MCMC(
+        BarkerMH(data_conditioned_model), num_samples=NUM_SAMPLES, num_warmup=NUM_WARMUP
+    )
     mcmc.run(mcmc_key)
     posterior_samples = mcmc.get_samples()
     assert "rho" in posterior_samples
@@ -171,7 +173,9 @@ def test_continuous_time_lti_gaussian_mcmc_smoke(
     data_conditioned_model, true_params, synthetic, _, _ = (
         data_conditioned_continuous_time_lti_gaussian
     )
-    mcmc = MCMC(NUTS(data_conditioned_model), num_samples=10, num_warmup=10)
+    mcmc = MCMC(
+        NUTS(data_conditioned_model), num_samples=NUM_SAMPLES, num_warmup=NUM_WARMUP
+    )
     mcmc.run(mcmc_key)
     posterior_samples = mcmc.get_samples()
     assert "rho" in posterior_samples
@@ -185,7 +189,9 @@ def test_continuous_time_lti_simplified_mcmc_smoke(
     data_conditioned_model, true_params, synthetic, _ = (
         data_conditioned_continuous_time_lti_simplified
     )
-    mcmc = MCMC(NUTS(data_conditioned_model), num_samples=10, num_warmup=10)
+    mcmc = MCMC(
+        NUTS(data_conditioned_model), num_samples=NUM_SAMPLES, num_warmup=NUM_WARMUP
+    )
     mcmc.run(mcmc_key)
     posterior_samples = mcmc.get_samples()
     assert "rho" in posterior_samples
@@ -198,7 +204,9 @@ def test_continuous_time_lti_gaussian_dpf_mcmc_smoke(
     data_conditioned_model, true_params, synthetic, _ = (
         data_conditioned_continuous_time_lti_gaussian_dpf
     )
-    mcmc = MCMC(BarkerMH(data_conditioned_model), num_samples=10, num_warmup=10)
+    mcmc = MCMC(
+        BarkerMH(data_conditioned_model), num_samples=NUM_SAMPLES, num_warmup=NUM_WARMUP
+    )
     mcmc.run(mcmc_key)
     posterior_samples = mcmc.get_samples()
     assert "rho" in posterior_samples


### PR DESCRIPTION
Creates an environment variable `_PF_PARTICLES_SCALE` which defaults to 1.

It is a scale factor for particle filter particle counts.
`DYNESTYX_PF_PARTICLES_SCALE=0.01` in CI for ~100x faster PF-based tests.
