### PR TITLE
Try switching back to trusted publisher in `python-publish.yml`

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,6 +19,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -32,7 +34,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Maybe bumping the `gh-action-pypi-publish` workflow tag will help...