### PR TITLE
Pin arviz version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "matplotlib>=3.10.7",
     "numpyro>=0.19.0",
     "pytest>=9.0.1",
-    "arviz>=0.18.0",
+    "arviz>=0.18.0,<1.0.0",
     "blackjax>=1.3",
     "pytkdocs-tweaks>=0.0.8",
     "mkdocstrings[python]>=1.0.1",
@@ -80,5 +80,5 @@ select = [
 ]
 
 [[tool.mypy.overrides]]
-module = ["cd_dynamax.*", "numpyro.*", "blackjax.*", "cuthbert.*", "cuthbertlib.*", "optax.*", "arviz.*"]
+module = ["cd_dynamax.*", "numpyro.*", "blackjax.*", "cuthbert.*", "cuthbertlib.*", "optax.*"]
 follow_untyped_imports = true


### PR DESCRIPTION
#143 removed the uv.lock, which upgraded arviz into a backwards-incompatible version. This pins to a pre-1.0.0 version.