### PR TITLE
Use PyPI-based effectful

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "effectful @ git+https://github.com/BasisResearch/effectful.git",
+    "effectful",
     "cuthbert @ git+https://github.com/DanWaxman/cuthbert.git@b56783de77ef62804b8458463a7bf907c1296017#subdirectory=pkg/cuthbert",
     "cuthbertlib @ git+https://github.com/DanWaxman/cuthbert.git@b56783de77ef62804b8458463a7bf907c1296017#subdirectory=pkg/cuthbertlib",
     "cd-dynamax @ git+https://github.com/DanWaxman/cd_dynamax.git@dw-dpf",
@@ -54,7 +54,6 @@ packages = ["dynestyx"]
 allow-direct-references = true
 
 [tool.uv.sources]
-effectful = { git = "https://github.com/BasisResearch/effectful.git" }
 cuthbert = { git = "https://github.com/DanWaxman/cuthbert.git", rev = "b56783de77ef62804b8458463a7bf907c1296017", subdirectory = "pkg/cuthbert"}
 cd-dynamax = { git = "https://github.com/DanWaxman/cd_dynamax.git", rev = "dw-dpf" }
 


### PR DESCRIPTION
Progress towards #148. Tests pass, there doesn't seem any good reason to use the git version anymore.