### PR TITLE
Detect use of typed keys in CD-Dynamax integration

### DIFF
--- a/dynestyx/inference/integrations/cd_dynamax/continuous.py
+++ b/dynestyx/inference/integrations/cd_dynamax/continuous.py
@@ -49,6 +49,13 @@ def _config_to_cd_dynamax_filter_kwargs(
     key,
 ) -> dict:
     """Build the filter_kwargs dict passed to cd_dynamax_model.filter()."""
+
+    # cd-dynamax uses the legacy PRNG key interface, but newer numpyro uses typed keys.
+    # We should convert accordingly.
+    # https://docs.jax.dev/en/latest/jax.random.html#module-jax.random
+    if jnp.issubdtype(key.dtype, jax.dtypes.prng_key):
+        key = jax.random.key_data(key)
+
     base = {
         "params": params,
         "emissions": obs_values,


### PR DESCRIPTION
The use of typed keys broke DPF code in CD-Dynamax, which assumed the legacy uint32 format. This commit detects the use of a typed key, and uses `key_data` to convert back to the legacy format.

Closes #179. Tests pass locally. 