### PR TITLE
Upgrade cuthbert to PyPI version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 ]
 dependencies = [
     "effectful",
-    "cuthbert @ git+https://github.com/state-space-models/cuthbert.git#subdirectory=pkg/cuthbert",
-    "cuthbertlib @ git+https://github.com/state-space-models/cuthbert.git#subdirectory=pkg/cuthbertlib",
+    "cuthbert>=0.0.9",
+    "cuthbertlib>=0.0.9",
     "cd-dynamax @ git+https://github.com/HD-UQ/cd_dynamax.git@public",
     "matplotlib>=3.10.7",
     "numpyro>=0.19.0",
@@ -55,7 +55,6 @@ packages = ["dynestyx"]
 allow-direct-references = true
 
 [tool.uv.sources]
-cuthbert = { git = "https://github.com/state-space-models/cuthbert.git", subdirectory = "pkg/cuthbert"}
 cd-dynamax = { git = "https://github.com/HD-UQ/cd_dynamax.git", branch = "public" }
 
 [dependency-groups]


### PR DESCRIPTION
`cuthbert` 0.0..9 just released, which includes the features (stop gradient DPF + fixed KF gradients) we were using the git version for. This is another piece of progress towards #148. 