### PR TITLE
test and fix log softmax stability in particles_to_delta_mixtures

### DIFF
--- a/dynestyx/inference/hmm_filters.py
+++ b/dynestyx/inference/hmm_filters.py
@@ -150,16 +150,15 @@ def hmm_filter(
 
         # Update: p(x_t | y_{1:t}) \propto p(y_t | x_t) p(x_t | y_{1:t-1})
         log_alpha = log_emit_t + log_pred
-
+        log_filt = jax.nn.log_softmax(log_alpha, axis=-1)
         log_Z = logsumexp(log_alpha, axis=-1)
-        log_filt = log_alpha - log_Z
 
         return (log_filt, loglik + log_Z), log_filt
 
     # t = 0
     log_alpha0 = log_pi + log_emit_seq[0]
     log_Z0 = logsumexp(log_alpha0, axis=-1)
-    log_filt0 = log_alpha0 - log_Z0
+    log_filt0 = jax.nn.log_softmax(log_alpha0, axis=-1)
 
     # t = 1..T-1
     # Use normalized filtered state (log_filt0) in carry for numerical stability

--- a/dynestyx/inference/integrations/cuthbert/discrete.py
+++ b/dynestyx/inference/integrations/cuthbert/discrete.py
@@ -391,10 +391,7 @@ def _add_sites_pf(
     )
 
     if need_filtered_means:
-        log_weights_norm = log_weights - jax.scipy.special.logsumexp(
-            log_weights, axis=1, keepdims=True
-        )
-        w = jnp.exp(log_weights_norm)[..., None]  # (T+1, n_particles, 1)
+        w = jax.nn.softmax(log_weights, axis=1)[..., None]  # (T+1, n_particles, 1)
         filtered_means = jnp.sum(particles * w, axis=1)  # (T+1, state_dim)
 
     if add_filtered_states_cov or add_filtered_states_cov_diag:

--- a/dynestyx/inference/integrations/utils.py
+++ b/dynestyx/inference/integrations/utils.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import jax
+import jax.numpy as jnp
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
 
@@ -79,10 +80,8 @@ def particles_to_delta_mixtures(
         f"got {particles.shape[:2]} and {log_weights.shape[:2]}."
     )
 
-    log_weights_norm = log_weights - jax.scipy.special.logsumexp(
-        log_weights, axis=-1, keepdims=True
-    )
+    z = log_weights - log_weights.max(axis=-1, keepdims=True)
+    z_norm = z - jnp.log(jnp.sum(jnp.exp(z), axis=-1, keepdims=True))
     return [
-        WeightedParticles(particles[i], log_weights_norm[i])
-        for i in range(particles.shape[0])
+        WeightedParticles(particles[i], z_norm[i]) for i in range(particles.shape[0])
     ]

--- a/dynestyx/inference/integrations/utils.py
+++ b/dynestyx/inference/integrations/utils.py
@@ -80,8 +80,7 @@ def particles_to_delta_mixtures(
         f"got {particles.shape[:2]} and {log_weights.shape[:2]}."
     )
 
-    z = log_weights - log_weights.max(axis=-1, keepdims=True)
-    z_norm = z - jnp.log(jnp.sum(jnp.exp(z), axis=-1, keepdims=True))
+    z = jax.nn.log_softmax(log_weights, axis=-1)
     return [
-        WeightedParticles(particles[i], z_norm[i]) for i in range(particles.shape[0])
+        WeightedParticles(particles[i], z[i]) for i in range(particles.shape[0])
     ]

--- a/dynestyx/inference/integrations/utils.py
+++ b/dynestyx/inference/integrations/utils.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import jax
-import jax.numpy as jnp
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
 
@@ -81,6 +80,4 @@ def particles_to_delta_mixtures(
     )
 
     z = jax.nn.log_softmax(log_weights, axis=-1)
-    return [
-        WeightedParticles(particles[i], z[i]) for i in range(particles.shape[0])
-    ]
+    return [WeightedParticles(particles[i], z[i]) for i in range(particles.shape[0])]

--- a/tests/test_inference_integrations_utils.py
+++ b/tests/test_inference_integrations_utils.py
@@ -1,0 +1,12 @@
+import jax
+import jax.numpy as jnp
+
+from dynestyx.inference.integrations.utils import particles_to_delta_mixtures
+
+
+def test_particles_to_delta_mixtures():
+    T, N, D = 1, 7, 11
+    x = jax.random.normal(jax.random.key(1), shape=[T, N, D], dtype="float32")
+    z = -1e10 * jnp.ones([T, N], dtype="float32")
+    [dist] = particles_to_delta_mixtures(x, z)
+    assert jnp.isclose(jnp.exp(dist.log_weights).sum(), 1)


### PR DESCRIPTION
This fixes an issue with the log softmax computation for large negative and uniform log probabilities. In isolation the issue is that these two expressions return very different values:

```
w = -1e10 * jnp.ones([11])
w_max = w.max()
print((w - w_max) - jnp.log(jnp.sum(jnp.exp(w - w_max))))
print(w - (w_max + jnp.log(jnp.sum(jnp.exp(w - w_max)))))
```

The latter returns all zeros, which is not a normalized log probability vector.