### PR TITLE
Move to PyPI dependencies fully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "effectful",
     "cuthbert>=0.0.9",
     "cuthbertlib>=0.0.9",
-    "cd-dynamax @ git+https://github.com/HD-UQ/cd_dynamax.git@public",
+    "cd-dynamax",
     "matplotlib>=3.10.7",
     "numpyro>=0.19.0",
     "pytest>=9.0.1",
@@ -53,9 +53,6 @@ packages = ["dynestyx"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
-
-[tool.uv.sources]
-cd-dynamax = { git = "https://github.com/HD-UQ/cd_dynamax.git", branch = "public" }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Moves our final non-PyPI dependency to a PyPI version. Closes #148. 