### PR TITLE
Better Document Filter Sources

### DIFF
--- a/dynestyx/inference/filter_configs.py
+++ b/dynestyx/inference/filter_configs.py
@@ -9,9 +9,16 @@ import jax.random as jr
 
 ResamplingBaseMethod = Literal["systematic", "multinomial", "stratified"]
 ResamplingDifferentiableMethod = Literal["stop_gradient", "straight_through", "soft"]
-FilterSource = Literal["cuthbert", "cd_dynamax", "dynestyx"]
 FilterEmissionOrder = Literal["zeroth", "first", "second"]
 FilterStateOrder = Literal["zeroth", "first", "second"]
+
+CuthbertOnlyFilterSource = Literal["cuthbert"]
+CDDynamaxOnlyFilterSource = Literal["cd_dynamax"]
+DynestyxOnlyFilterSource = Literal["dynestyx"]
+FilterSource = (
+    CuthbertOnlyFilterSource | CDDynamaxOnlyFilterSource | DynestyxOnlyFilterSource
+)
+CuthbertOrCDDynamaxFilterSource = CuthbertOnlyFilterSource | CDDynamaxOnlyFilterSource
 
 
 @dataclasses.dataclass
@@ -152,7 +159,7 @@ class EnKFConfig(BaseFilterConfig):
     )
     perturb_measurements: bool | None = None
     inflation_delta: float | None = None
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"
 
 
 @dataclasses.dataclass
@@ -261,7 +268,7 @@ class PFConfig(BaseFilterConfig):
         default_factory=PFResamplingConfig
     )
     ess_threshold_ratio: float = 0.7
-    filter_source: FilterSource = "cuthbert"
+    filter_source: CuthbertOnlyFilterSource = "cuthbert"
 
 
 @dataclasses.dataclass
@@ -308,7 +315,7 @@ class EKFConfig(BaseFilterConfig):
             [Available Online](https://users.aalto.fi/~ssarkka/pub/bfs_book_2023_online.pdf).
     """
 
-    filter_source: FilterSource = "cuthbert"
+    filter_source: CuthbertOrCDDynamaxFilterSource = "cuthbert"
     filter_emission_order: FilterEmissionOrder = "first"
 
 
@@ -368,7 +375,7 @@ class KFConfig(BaseFilterConfig):
         - For more details on the `cuthbert` implementation, see the [cuthbert documentation](https://state-space-models.github.io/cuthbert/cuthbert_api/gaussian/kalman/).
     """
 
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"
 
 
 @dataclasses.dataclass
@@ -415,7 +422,7 @@ class UKFConfig(BaseFilterConfig):
     alpha: float = math.sqrt(3)
     beta: int = 2
     kappa: int = 1
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"
 
 
 @dataclasses.dataclass
@@ -483,7 +490,7 @@ class ContinuousTimeKFConfig(BaseFilterConfig, ContinuousTimeConfig):
             [Available Online](https://users.aalto.fi/~asolin/sde-book/sde-book.pdf).
     """
 
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"
 
 
 @dataclasses.dataclass
@@ -513,7 +520,7 @@ class ContinuousTimeEnKFConfig(EnKFConfig, ContinuousTimeConfig):
             [Available Online](https://epubs.siam.org/doi/abs/10.1137/21M1434477).
     """
 
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"
 
 
 @dataclasses.dataclass
@@ -541,7 +548,7 @@ class ContinuousTimeDPFConfig(PFConfig, ContinuousTimeConfig):
         See `PFConfig` for more information.
     """
 
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"  # type: ignore[assignment]
     resampling_method: PFResamplingConfig = dataclasses.field(
         default_factory=lambda: PFResamplingConfig(base_method="multinomial")
     )
@@ -570,7 +577,7 @@ class ContinuousTimeEKFConfig(EKFConfig, ContinuousTimeConfig):
             [Available Online](https://users.aalto.fi/~asolin/sde-book/sde-book.pdf).
     """
 
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"
 
 
 @dataclasses.dataclass
@@ -596,7 +603,7 @@ class ContinuousTimeUKFConfig(UKFConfig, ContinuousTimeConfig):
             [Available Online](https://users.aalto.fi/~asolin/sde-book/sde-book.pdf).
     """
 
-    filter_source: FilterSource = "cd_dynamax"
+    filter_source: CDDynamaxOnlyFilterSource = "cd_dynamax"
 
 
 DiscreteTimeConfigs: tuple[type, ...] = (
@@ -649,7 +656,7 @@ class HMMConfig(BaseFilterConfig):
 
     record_filtered: bool | None = None
     record_log_filtered: bool | None = None
-    filter_source: FilterSource = "dynestyx"
+    filter_source: DynestyxOnlyFilterSource = "dynestyx"
 
 
 HMMConfigs: tuple[type, ...] = (HMMConfig,)


### PR DESCRIPTION
This commit/PR better documents filter sources by using different literal classes in the typing of each dataclass. For example, `ContinuousTimeDPFConfig` now has field `filter_source: CDDynamaxOnlyFilterSource`.

Resolves #122 