### PR TITLE
Cap JAX below 0.10 for NumPyro compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,10 @@ dependencies = [
     "jupyter>=1.1.1",
     "ipywidgets>=8.1.8",
     "equinox>=0.13.2",
-    "jax>=0.6.2",
-    "jaxlib>=0.6.2",
+    # NumPyro 0.20.1 currently fails to import with JAX 0.10.0
+    # (removed xla_pmap_p); cap until upstream compatibility lands.
+    "jax>=0.6.2,<0.10",
+    "jaxlib>=0.6.2,<0.10",
     "tfp-nightly>=0.26.0dev20250530",
     "orbax-checkpoint<0.11.3; sys_platform == 'win32'"
 ]


### PR DESCRIPTION
## Summary
- cap `jax` and `jaxlib` below `0.10`
- document that this is a temporary guard for the current NumPyro/JAX incompatibility

In response to https://github.com/pyro-ppl/numpyro/issues/2174

## Why
`numpyro==0.20.1` currently fails to import with `jax==0.10.0` because JAX removed `xla_pmap_p`. Since `dynestyx` depends on NumPyro and currently has no upper bound on JAX, package resolution can produce an environment that breaks before any dynestyx code runs.

This PR adds a temporary upper bound so users continue to resolve to a known-working JAX series until upstream compatibility lands.

## Verification
- verified the `pyproject.toml` metadata now resolves the intended bounds
- confirmed in isolated temp environments that `numpyro==0.20.1` fails to import under `jax==0.10.0` on both Python 3.12 and 3.13
