### PR TITLE
bump to 0.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dynestyx"
-version = "0.0.5"
+version = "0.0.6"
 description = "NumPyro integration for dynamical systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
- want latest version to protect new users from numpyro/jax version incompatibilities.