### PR TITLE
pin cd-dynamax version to >=0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "effectful",
     "cuthbert>=0.0.10",
     "cuthbertlib>=0.0.10",
-    "cd-dynamax",
+    "cd-dynamax>=0.3.3",
     "matplotlib>=3.10.7",
     "numpyro>=0.19.0",
     "pytest>=9.0.1",


### PR DESCRIPTION
Prior to v0.3.3 cd-dynamax release, state-dependent diffusion coefficients `L(x, u, t)` silently ignored the `x` argument, instead running `L(None, u, t)`.

This is fixed in v0.3.3: https://github.com/hd-UQ/cd_dynamax/pull/26