### PR TITLE
warn about silently ignoring times in discrete cd-dynamax EKF/UKF

### DIFF
--- a/dynestyx/inference/filter_configs.py
+++ b/dynestyx/inference/filter_configs.py
@@ -291,9 +291,10 @@ class EKFConfig(BaseFilterConfig):
 
     In the current interface with the `cd_dynamax` discrete-time backend,
     time-varying models silently ignore absolute time arguments.
-    For genuinely time-varying discrete-time models, use
-    `filter_source="cuthbert"` instead. Only use `filter_source="cd_dynamax"`
-    for time-invariant models.
+    For genuinely time-varying discrete-time models, use a
+    backend/configuration that preserves absolute time semantics, such as
+    `EnKFConfig(filter_source="cuthbert")`. Only use
+    `filter_source="cd_dynamax"` for time-invariant models.
 
     Attributes:
         filter_emission_order (FilterEmissionOrder): Linearisation order for
@@ -421,9 +422,10 @@ class UKFConfig(BaseFilterConfig):
 
     In the current interface with the `cd_dynamax` discrete-time backend,
     time-varying models silently ignore absolute time arguments.
-    For genuinely time-varying discrete-time models, use
-    `filter_source="cuthbert"` instead. Only use `filter_source="cd_dynamax"`
-    for time-invariant models.
+    For genuinely time-varying discrete-time models, use a
+    backend/configuration that preserves absolute time semantics, such as
+    `EKFConfig(filter_source="cuthbert")`. Only use
+    `filter_source="cd_dynamax"` for time-invariant models.
 
     Attributes:
         alpha (float): Spread of sigma points around the current mean.

--- a/dynestyx/inference/filter_configs.py
+++ b/dynestyx/inference/filter_configs.py
@@ -289,6 +289,12 @@ class EKFConfig(BaseFilterConfig):
 
     This is exact (but wasteful) for linear-Gaussian models.
 
+    In the current interface with the `cd_dynamax` discrete-time backend,
+    time-varying models silently ignore absolute time arguments.
+    For genuinely time-varying discrete-time models, use
+    `filter_source="cuthbert"` instead. Only use `filter_source="cd_dynamax"`
+    for time-invariant models.
+
     Attributes:
         filter_emission_order (FilterEmissionOrder): Linearisation order for
             the observation function. `"first"` *(default)* is the standard
@@ -412,6 +418,12 @@ class UKFConfig(BaseFilterConfig):
 
     The default parameters (`alpha`, `beta`, `kappa`) work well for most
     problems; they rarely need to be changed.
+
+    In the current interface with the `cd_dynamax` discrete-time backend,
+    time-varying models silently ignore absolute time arguments.
+    For genuinely time-varying discrete-time models, use
+    `filter_source="cuthbert"` instead. Only use `filter_source="cd_dynamax"`
+    for time-invariant models.
 
     Attributes:
         alpha (float): Spread of sigma points around the current mean.

--- a/dynestyx/inference/integrations/cd_dynamax/utils.py
+++ b/dynestyx/inference/integrations/cd_dynamax/utils.py
@@ -450,9 +450,11 @@ def gaussian_to_nlgssm_params(dynamics: DynamicalModel) -> ParamsNLGSSM:
 
     if isinstance(evo, GaussianStateEvolution) or isinstance(obs, GaussianObservation):
         warnings.warn(
-            "cd_dynamax discrete EKF/UKF ignores absolute time arguments in "
-            "GaussianStateEvolution/GaussianObservation. Use "
-            "filter_source='cuthbert' for genuinely time-varying discrete-time models.",
+            "cd_dynamax discrete-time filters ignore absolute time arguments in "
+            "GaussianStateEvolution/GaussianObservation. For genuinely "
+            "time-varying discrete-time models, use a filter/backend that "
+            "preserves absolute time semantics, "
+            "such as EnKFConfig(filter_source='cuthbert').",
             stacklevel=2,
         )
 

--- a/dynestyx/inference/integrations/cd_dynamax/utils.py
+++ b/dynestyx/inference/integrations/cd_dynamax/utils.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -445,6 +446,14 @@ def gaussian_to_nlgssm_params(dynamics: DynamicalModel) -> ParamsNLGSSM:
             "cd_dynamax discrete EKF/UKF requires array-valued process covariance. "
             "Received callable state_evolution.cov. Use a fixed covariance matrix, "
             "or choose a backend that supports callable covariances."
+        )
+
+    if isinstance(evo, GaussianStateEvolution) or isinstance(obs, GaussianObservation):
+        warnings.warn(
+            "cd_dynamax discrete EKF/UKF ignores absolute time arguments in "
+            "GaussianStateEvolution/GaussianObservation. Use "
+            "filter_source='cuthbert' for genuinely time-varying discrete-time models.",
+            stacklevel=2,
         )
 
     if isinstance(ic, dist.MultivariateNormal):


### PR DESCRIPTION
Addresses #231 by adding a warning anytime a user runs CD-Dynamax EKF/UKF discrete-time.

Can check performance by running below script

```python

import warnings

import jax.numpy as jnp
import jax.random as jr
import numpyro
import numpyro.distributions as dist
from numpyro.infer import Predictive

import dynestyx as dsx
from dynestyx.inference.filters import EKFConfig, Filter
from dynestyx.inference.mcmc import MCMCInference
from dynestyx.inference.mcmc_configs import NUTSConfig
from dynestyx.simulators import DiscreteTimeSimulator


def time_varying_model(
    obs_times=None,
    obs_values=None,
    ctrl_times=None,
    ctrl_values=None,
    predict_times=None,
    theta=None,
):
    del ctrl_times, ctrl_values
    theta = numpyro.sample("theta", dist.Normal(0.0, 0.2), obs=theta)

    dynamics = dsx.DynamicalModel(
        control_dim=0,
        initial_condition=dist.MultivariateNormal(
            loc=jnp.zeros(1),
            covariance_matrix=0.1 * jnp.eye(1),
        ),
        state_evolution=dsx.GaussianStateEvolution(
            F=lambda x, u, t_now, t_next: x + theta * (1.0 + t_now + 2.0 * t_next),
            cov=0.05 * jnp.eye(1),
        ),
        observation_model=dsx.GaussianObservation(
            h=lambda x, u, t: x + 0.1 * t,
            R=0.05 * jnp.eye(1),
        ),
    )

    return dsx.sample(
        "f",
        dynamics,
        obs_times=obs_times,
        obs_values=obs_values,
        predict_times=predict_times,
    )


def make_data():
    obs_times = jnp.array([0.0, 1.0, 2.0, 3.0])
    with DiscreteTimeSimulator():
        synthetic = Predictive(
            time_varying_model,
            num_samples=1,
            exclude_deterministic=False,
        )(
            jr.PRNGKey(0),
            theta=jnp.array(0.05),
            predict_times=obs_times,
        )
    obs_values = jnp.asarray(synthetic["f_observations"][0]).reshape((-1, 1))
    return obs_times, obs_values


def main():
    warnings.simplefilter("default")
    obs_times, obs_values = make_data()

    with Filter(filter_config=EKFConfig(filter_source="cd_dynamax")):
        inference = MCMCInference(
            mcmc_config=NUTSConfig(
                num_samples=10,
                num_warmup=10,
                num_chains=1,
                mcmc_source="numpyro",
            ),
            model=time_varying_model,
        )
        samples = inference.run(jr.PRNGKey(1), obs_times, obs_values)

    print("Posterior sample keys:", sorted(samples))
    print("theta sample:", samples["theta"])


if __name__ == "__main__":
    main()
```