### PR TITLE
Strengthen NaN checks in smoke tests and surface nested-plate NaN bug

### DIFF
--- a/tests/test_filter_simulator.py
+++ b/tests/test_filter_simulator.py
@@ -28,6 +28,10 @@ from tests.fixtures import (
     data_conditioned_jumpy_controls_ode,
     data_conditioned_jumpy_controls_sde,
 )
+from tests.test_utils import (
+    assert_trace_sites_exist_and_field_all_finite,
+    assert_tree_all_finite,
+)
 
 
 def test_filter_sdesimulator_known_params():
@@ -84,8 +88,12 @@ def test_filter_simulator_sde_explicit(source):
     with SDESimulator(source=source):
         with trace() as tr, seed(rng_seed=rng_key):
             data_conditioned_model()
-    assert "f_filtered_states_mean" in tr
-    assert "f_marginal_loglik" in tr
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_filtered_states_mean",
+        "f_marginal_loglik",
+        where="explicit SDE filter trace",
+    )
 
 
 def test_filter_simulator_ode_explicit():
@@ -95,8 +103,12 @@ def test_filter_simulator_ode_explicit():
     with Simulator():
         with trace() as tr, seed(rng_seed=rng_key):
             data_conditioned_model()
-    assert "f_filtered_states_mean" in tr
-    assert "f_marginal_loglik" in tr
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_filtered_states_mean",
+        "f_marginal_loglik",
+        where="explicit ODE filter trace",
+    )
 
 
 @pytest.mark.parametrize("source", ["diffrax", "em_scan"])
@@ -140,10 +152,14 @@ def test_filter_sdesimulator_predict_times_n_simulations(source):
                     predict_times=predict_times,
                 )
 
-    assert "f_predicted_states" in tr
-    assert "f_predicted_times" in tr
-    assert "f_predicted_observations" in tr
-    assert "f_filtered_states_mean" in tr
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_states",
+        "f_predicted_times",
+        "f_predicted_observations",
+        "f_filtered_states_mean",
+        where="SDE filter + simulator trace",
+    )
     pred_states = tr["f_predicted_states"]["value"]
     assert pred_states.shape == (n_sim, len(predict_times), 3)
 
@@ -189,10 +205,14 @@ def test_filter_discretetimesimulator_predict_times_n_simulations():
                     predict_times=predict_times,
                 )
 
-    assert "f_predicted_states" in tr
-    assert "f_predicted_times" in tr
-    assert "f_predicted_observations" in tr
-    assert "f_filtered_states_mean" in tr
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_states",
+        "f_predicted_times",
+        "f_predicted_observations",
+        "f_filtered_states_mean",
+        where="discrete filter + simulator trace",
+    )
     pred_states = tr["f_predicted_states"]["value"]
     assert pred_states.shape == (n_sim, len(predict_times), 2), pred_states.shape
 
@@ -239,5 +259,12 @@ def test_filter_discretetimesimulator_pf_predict_times_particle_sampling():
     x0_keys = [k for k in tr if k.startswith("f_") and k.endswith("_x_0")]
     assert x0_keys, "Expected rollout segment initial-state sites."
     x0 = tr[x0_keys[0]]["value"]
+    assert_tree_all_finite(
+        {
+            "predicted_states": pred_states,
+            "segment_initial_state": x0,
+        },
+        where="PF rollout trace",
+    )
     assert x0.shape[0] == n_sim
     assert not jnp.allclose(x0[0], x0[1])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -30,6 +30,10 @@ from tests.fixtures import (
     data_conditioned_jumpy_controls_sde,
 )
 from tests.models import discrete_time_l63_model, discrete_time_lti_simplified_model
+from tests.test_utils import (
+    assert_trace_sites_exist_and_field_all_finite,
+    assert_tree_all_finite,
+)
 
 
 @pytest.mark.parametrize(
@@ -166,13 +170,30 @@ def test_compute_cuthbert_filter_returns_observation_aligned_states(filter_confi
     )
 
     assert jnp.ndim(marginal_loglik) == 0
+    assert_tree_all_finite({"marginal_loglik": marginal_loglik}, where="filter output")
     assert states.log_normalizing_constant.shape[0] == len(obs_times)
     assert states.model_inputs.y.shape[0] == len(obs_times)
 
     if isinstance(filter_config, PFConfig):
+        assert_tree_all_finite(
+            {
+                "particles": states.particles,
+                "log_weights": states.log_weights,
+                "log_normalizing_constant": states.log_normalizing_constant,
+            },
+            where="PF filter states",
+        )
         assert states.particles.shape[0] == len(obs_times)
         assert states.log_weights.shape[0] == len(obs_times)
     else:
+        assert_tree_all_finite(
+            {
+                "mean": states.mean,
+                "chol_cov": states.chol_cov,
+                "log_normalizing_constant": states.log_normalizing_constant,
+            },
+            where="Gaussian filter states",
+        )
         assert states.mean.shape[0] == len(obs_times)
         assert states.chol_cov.shape[0] == len(obs_times)
 
@@ -193,6 +214,14 @@ def test_compute_cuthbert_filter_can_return_raw_cuthbert_states():
     assert states.model_inputs.y.shape[0] == len(obs_times) + 1
     assert states.mean.shape[0] == len(obs_times) + 1
     assert states.chol_cov.shape[0] == len(obs_times) + 1
+    assert_tree_all_finite(
+        {
+            "log_normalizing_constant": states.log_normalizing_constant,
+            "mean": states.mean,
+            "chol_cov": states.chol_cov,
+        },
+        where="raw cuthbert filter states",
+    )
 
 
 @pytest.mark.parametrize(
@@ -224,12 +253,26 @@ def test_cuthbert_filtered_distribution_shapes_match_observations(filter_config)
         assert filtered_dist.event_shape == (dynamics.state_dim,)
 
         if isinstance(filter_config, PFConfig):
+            assert_tree_all_finite(
+                {
+                    "particles": filtered_dist.particles,
+                    "log_weights": filtered_dist.log_weights,
+                },
+                where="filtered distribution",
+            )
             assert filtered_dist.particles.shape == (
                 filter_config.n_particles,
                 dynamics.state_dim,
             )
             assert filtered_dist.log_weights.shape == (filter_config.n_particles,)
         else:
+            assert_tree_all_finite(
+                {
+                    "mean": filtered_dist.mean,
+                    "covariance_matrix": filtered_dist.covariance_matrix,
+                },
+                where="filtered distribution",
+            )
             assert filtered_dist.mean.shape == (dynamics.state_dim,)
             assert filtered_dist.covariance_matrix.shape == (
                 dynamics.state_dim,
@@ -352,13 +395,21 @@ def test_cuthbert_enkf_records_filtered_gaussian_sites():
         with Filter(filter_config=filter_config):
             substituted(obs_times=obs_times, obs_values=obs_values)
 
-    assert "f_marginal_loglik" in tr
     assert tr["f_filtered_states_mean"]["value"].shape == (len(obs_times), 2)
     assert tr["f_filtered_states_cov"]["value"].shape == (len(obs_times), 2, 2)
     assert tr["f_filtered_states_cov_diag"]["value"].shape == (len(obs_times), 2)
     assert tr["f_filtered_states_chol_cov"]["value"].shape[:2] == (
         len(obs_times),
         2,
+    )
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_marginal_loglik",
+        "f_filtered_states_mean",
+        "f_filtered_states_cov",
+        "f_filtered_states_cov_diag",
+        "f_filtered_states_chol_cov",
+        where="recorded filter trace",
     )
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -395,13 +395,6 @@ def test_cuthbert_enkf_records_filtered_gaussian_sites():
         with Filter(filter_config=filter_config):
             substituted(obs_times=obs_times, obs_values=obs_values)
 
-    assert tr["f_filtered_states_mean"]["value"].shape == (len(obs_times), 2)
-    assert tr["f_filtered_states_cov"]["value"].shape == (len(obs_times), 2, 2)
-    assert tr["f_filtered_states_cov_diag"]["value"].shape == (len(obs_times), 2)
-    assert tr["f_filtered_states_chol_cov"]["value"].shape[:2] == (
-        len(obs_times),
-        2,
-    )
     assert_trace_sites_exist_and_field_all_finite(
         tr,
         "f_marginal_loglik",
@@ -410,6 +403,13 @@ def test_cuthbert_enkf_records_filtered_gaussian_sites():
         "f_filtered_states_cov_diag",
         "f_filtered_states_chol_cov",
         where="recorded filter trace",
+    )
+    assert tr["f_filtered_states_mean"]["value"].shape == (len(obs_times), 2)
+    assert tr["f_filtered_states_cov"]["value"].shape == (len(obs_times), 2, 2)
+    assert tr["f_filtered_states_cov_diag"]["value"].shape == (len(obs_times), 2)
+    assert tr["f_filtered_states_chol_cov"]["value"].shape[:2] == (
+        len(obs_times),
+        2,
     )
 
 

--- a/tests/test_hierarchical_simulator_discretizer_smokes.py
+++ b/tests/test_hierarchical_simulator_discretizer_smokes.py
@@ -36,6 +36,10 @@ from dynestyx.models import (
 )
 from dynestyx.models.lti_dynamics import LTI_continuous, LTI_discrete
 from dynestyx.models.state_evolution import AffineDrift
+from tests.test_utils import (
+    assert_trace_sites_exist_and_field_all_finite,
+    assert_tree_all_finite,
+)
 
 
 def _plate_discrete_lti_model(
@@ -228,6 +232,13 @@ def test_plate_forward_discrete_ode_sde_shapes(source):
     with DiscreteTimeSimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(0)):
             _plate_discrete_lti_model(predict_times=t, M=2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        "f_observations",
+        where="plate discrete forward trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 1, len(t))
     assert tr["f_states"]["value"].shape[:3] == (2, 1, len(t))
     assert tr["f_observations"]["value"].shape[:3] == (2, 1, len(t))
@@ -235,6 +246,13 @@ def test_plate_forward_discrete_ode_sde_shapes(source):
     with ODESimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(1)):
             _plate_continuous_ode_model(predict_times=t, M=2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        "f_observations",
+        where="plate ODE forward trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 1, len(t))
     assert tr["f_states"]["value"].shape[:3] == (2, 1, len(t))
     assert tr["f_observations"]["value"].shape[:3] == (2, 1, len(t))
@@ -242,6 +260,13 @@ def test_plate_forward_discrete_ode_sde_shapes(source):
     with SDESimulator(source=source):
         with trace() as tr, seed(rng_seed=jr.PRNGKey(2)):
             _plate_continuous_sde_model(predict_times=t, M=2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        "f_observations",
+        where="plate SDE forward trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 1, len(t))
     assert tr["f_states"]["value"].shape[:3] == (2, 1, len(t))
     assert tr["f_observations"]["value"].shape[:3] == (2, 1, len(t))
@@ -255,6 +280,12 @@ def test_plate_conditioning_discrete_single_and_nested():
     with DiscreteTimeSimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(3)):
             _plate_discrete_lti_model(obs_times=t, obs_values=obs_single, M=2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        where="plate discrete conditioning trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 1, len(t))
     assert tr["f_states"]["value"].shape[:3] == (2, 1, len(t))
 
@@ -273,6 +304,12 @@ def test_plate_conditioning_ode_single():
     with ODESimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(5)):
             _plate_continuous_ode_model(obs_times=t, obs_values=obs, M=2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        where="plate ODE conditioning trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 1, len(t))
     assert tr["f_states"]["value"].shape[:3] == (2, 1, len(t))
 
@@ -283,6 +320,13 @@ def test_plate_nonlinear_discrete_single_sample_under_plate():
     with DiscreteTimeSimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(16)):
             _plate_nonlinear_discrete_model(predict_times=t, M=2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        "f_observations",
+        where="plate nonlinear discrete forward trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 1, len(t))
     assert tr["f_states"]["value"].shape[:3] == (2, 1, len(t))
     assert tr["f_observations"]["value"].shape[:3] == (2, 1, len(t))
@@ -297,6 +341,12 @@ def test_plate_nonlinear_discrete_single_sample_under_plate():
                     predict_times=t,
                     M=2,
                 )
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_times",
+        "f_predicted_states",
+        where="plate nonlinear discrete rollout trace",
+    )
     assert tr["f_predicted_times"]["value"].shape == (2, 1, len(t))
     assert tr["f_predicted_states"]["value"].shape[:3] == (2, 1, len(t))
 
@@ -325,6 +375,12 @@ def test_plate_rollout_discrete_gaussian_pf_hmm():
                     predict_times=predict_times,
                     M=2,
                 )
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_times",
+        "f_predicted_states",
+        where="plate Gaussian rollout trace",
+    )
     assert tr["f_predicted_times"]["value"].shape == (2, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape[:3] == (2, 1, len(predict_times))
 
@@ -343,6 +399,12 @@ def test_plate_rollout_discrete_gaussian_pf_hmm():
                     predict_times=predict_times,
                     M=2,
                 )
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_times",
+        "f_predicted_states",
+        where="plate PF rollout trace",
+    )
     assert tr["f_predicted_times"]["value"].shape == (2, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape[:3] == (2, 1, len(predict_times))
 
@@ -355,6 +417,12 @@ def test_plate_rollout_discrete_gaussian_pf_hmm():
                     predict_times=predict_times,
                     M=2,
                 )
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_times",
+        "f_predicted_states",
+        where="plate HMM rollout trace",
+    )
     assert tr["f_predicted_times"]["value"].shape == (2, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape[:3] == (2, 1, len(predict_times))
 
@@ -374,6 +442,12 @@ def test_plate_rollout_discrete_cuthbert_kf_keeps_filtered_time_alignment():
                     M=2,
                 )
 
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_times",
+        "f_predicted_states",
+        where="plate cuthbert rollout trace",
+    )
     assert tr["f_predicted_times"]["value"].shape == (2, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape[:3] == (2, 1, len(predict_times))
     assert jnp.array_equal(tr["f_predicted_times"]["value"][0, 0], predict_times)
@@ -604,14 +678,17 @@ def _nested_plate_continuous_dirac_for_discretizer_model(
             )
 
 
-def _assert_hierarchical_dirac_shapes(tr, plate_shape, t, state_dim):
+def _assert_hierarchical_dirac_shapes_and_finite(tr, plate_shape, t, state_dim):
     states = tr["f_states"]["value"]
     observations = tr["f_observations"]["value"]
     expected = plate_shape + (1, len(t), state_dim)
+    assert_tree_all_finite(
+        (states, observations),
+        where="hierarchical Dirac trace",
+    )
     assert states.shape == expected
     assert observations.shape == expected
-    assert jnp.array_equal(jnp.isnan(states), jnp.isnan(observations))
-    assert jnp.allclose(jnp.nan_to_num(states), jnp.nan_to_num(observations))
+    assert jnp.allclose(states, observations)
 
 
 def _squeeze_n_sim_axis(observations, plate_ndim):
@@ -626,6 +703,13 @@ def test_plate_discretizer_forward_and_rollout():
         with Discretizer():
             with trace() as tr, seed(rng_seed=jr.PRNGKey(12)):
                 _plate_continuous_for_discretizer_model(predict_times=obs_times, M=2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        "f_observations",
+        where="plate discretizer forward trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 1, len(obs_times))
     obs = tr["f_observations"]["value"][:, 0]
 
@@ -639,6 +723,12 @@ def test_plate_discretizer_forward_and_rollout():
                         predict_times=predict_times,
                         M=2,
                     )
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_times",
+        "f_predicted_states",
+        where="plate discretizer rollout trace",
+    )
     assert tr["f_predicted_times"]["value"].shape == (2, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape[:3] == (2, 1, len(predict_times))
 
@@ -653,6 +743,13 @@ def test_nested_plate_discretizer_forward_shapes():
                     predict_times=obs_times, G=2, M=2
                 )
 
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_times",
+        "f_states",
+        "f_observations",
+        where="nested plate discretizer forward trace",
+    )
     assert tr["f_times"]["value"].shape == (2, 2, 1, len(obs_times))
     assert tr["f_states"]["value"].shape == (2, 2, 1, len(obs_times), 2)
     assert tr["f_observations"]["value"].shape == (2, 2, 1, len(obs_times), 1)
@@ -682,6 +779,13 @@ def test_nested_plate_discretizer_filter_rollout_shapes():
                         M=2,
                     )
 
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_predicted_times",
+        "f_predicted_states",
+        "f_marginal_loglik",
+        where="nested plate discretizer rollout trace",
+    )
     assert tr["f_predicted_times"]["value"].shape == (2, 2, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape == (2, 2, 1, len(predict_times), 2)
     assert tr["f_marginal_loglik"]["value"].shape == (2, 2)
@@ -694,28 +798,32 @@ def test_plate_discrete_dirac_forward_and_conditioning_shapes():
     with DiscreteTimeSimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(22)):
             _plate_discrete_dirac_model(predict_times=t, M=2)
-    _assert_hierarchical_dirac_shapes(tr, (2,), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2,), t, state_dim=2)
     obs = _squeeze_n_sim_axis(tr["f_observations"]["value"], plate_ndim=1)
 
     with DiscreteTimeSimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(23)):
             _plate_discrete_dirac_model(obs_times=t, obs_values=obs, M=2)
-    _assert_hierarchical_dirac_shapes(tr, (2,), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2,), t, state_dim=2)
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Nested plate discrete Dirac rollout currently emits NaNs in states.",
+)
 def test_nested_plate_discrete_dirac_forward_and_conditioning_shapes():
     t = jnp.arange(4.0)
 
     with DiscreteTimeSimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(24)):
             _nested_plate_discrete_dirac_model(predict_times=t, G=2, M=2)
-    _assert_hierarchical_dirac_shapes(tr, (2, 2), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2, 2), t, state_dim=2)
     obs = _squeeze_n_sim_axis(tr["f_observations"]["value"], plate_ndim=2)
 
     with DiscreteTimeSimulator():
         with trace() as tr, seed(rng_seed=jr.PRNGKey(25)):
             _nested_plate_discrete_dirac_model(obs_times=t, obs_values=obs, G=2, M=2)
-    _assert_hierarchical_dirac_shapes(tr, (2, 2), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2, 2), t, state_dim=2)
 
 
 def test_plate_discretized_dirac_forward_and_conditioning_shapes():
@@ -725,7 +833,7 @@ def test_plate_discretized_dirac_forward_and_conditioning_shapes():
         with Discretizer():
             with trace() as tr, seed(rng_seed=jr.PRNGKey(26)):
                 _plate_continuous_dirac_for_discretizer_model(predict_times=t, M=2)
-    _assert_hierarchical_dirac_shapes(tr, (2,), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2,), t, state_dim=2)
     obs = _squeeze_n_sim_axis(tr["f_observations"]["value"], plate_ndim=1)
 
     with DiscreteTimeSimulator():
@@ -734,7 +842,7 @@ def test_plate_discretized_dirac_forward_and_conditioning_shapes():
                 _plate_continuous_dirac_for_discretizer_model(
                     obs_times=t, obs_values=obs, M=2
                 )
-    _assert_hierarchical_dirac_shapes(tr, (2,), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2,), t, state_dim=2)
 
 
 def test_nested_plate_discretized_dirac_forward_and_conditioning_shapes():
@@ -746,7 +854,7 @@ def test_nested_plate_discretized_dirac_forward_and_conditioning_shapes():
                 _nested_plate_continuous_dirac_for_discretizer_model(
                     predict_times=t, G=2, M=2
                 )
-    _assert_hierarchical_dirac_shapes(tr, (2, 2), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2, 2), t, state_dim=2)
     obs = _squeeze_n_sim_axis(tr["f_observations"]["value"], plate_ndim=2)
 
     with DiscreteTimeSimulator():
@@ -755,7 +863,7 @@ def test_nested_plate_discretized_dirac_forward_and_conditioning_shapes():
                 _nested_plate_continuous_dirac_for_discretizer_model(
                     obs_times=t, obs_values=obs, G=2, M=2
                 )
-    _assert_hierarchical_dirac_shapes(tr, (2, 2), t, state_dim=2)
+    _assert_hierarchical_dirac_shapes_and_finite(tr, (2, 2), t, state_dim=2)
 
 
 def _non_plate_discrete_model(predict_times=None):

--- a/tests/test_predictive_filter_simulator_shapes.py
+++ b/tests/test_predictive_filter_simulator_shapes.py
@@ -32,6 +32,7 @@ from tests.models import (
     discrete_time_lti_simplified_model,
     jumpy_controls_model_ode,
 )
+from tests.test_utils import assert_tree_all_finite
 
 
 def _gen_obs_sde(source: Literal["diffrax", "em_scan"]):
@@ -123,6 +124,14 @@ def test_predictive_filter_sdesimulator_shapes(num_samples, n_sim, source):
     pred_states = samples["f_predicted_states"]
     pred_times = samples["f_predicted_times"]
     filtered_means = samples["f_filtered_states_mean"]
+    assert_tree_all_finite(
+        {
+            "predicted_states": pred_states,
+            "predicted_times": pred_times,
+            "filtered_states_mean": filtered_means,
+        },
+        where="predictive SDE samples",
+    )
 
     # Always (num_samples, n_sim, T, state_dim) for consistent shaping
     expected_T = len(predict_times)
@@ -159,6 +168,14 @@ def test_predictive_filter_discretetimesimulator_shapes(num_samples, n_sim):
     pred_states = samples["f_predicted_states"]
     pred_times = samples["f_predicted_times"]
     filtered_means = samples["f_filtered_states_mean"]
+    assert_tree_all_finite(
+        {
+            "predicted_states": pred_states,
+            "predicted_times": pred_times,
+            "filtered_states_mean": filtered_means,
+        },
+        where="predictive discrete samples",
+    )
 
     # Always (num_samples, n_sim, T, state_dim) for consistent shaping
     expected_T = len(predict_times)
@@ -201,6 +218,14 @@ def test_predictive_filter_odesimulator_shapes(num_samples, n_sim):
     pred_states = samples["f_predicted_states"]
     pred_times = samples["f_predicted_times"]
     filtered_means = samples["f_filtered_states_mean"]
+    assert_tree_all_finite(
+        {
+            "predicted_states": pred_states,
+            "predicted_times": pred_times,
+            "filtered_states_mean": filtered_means,
+        },
+        where="predictive ODE samples",
+    )
 
     # Always (num_samples, n_sim, T, state_dim) for consistent shaping
     assert pred_states.shape == (num_samples, n_sim, len(predict_times), state_dim)
@@ -251,6 +276,10 @@ def test_predictive_filter_discrete_rollout_uses_only_nonempty_segments():
     # For future-only rollout, only one segment should be simulated.
     x0_keys = [k for k in samples if re.fullmatch(r"f_\d+_x_0", k)]
     assert len(x0_keys) == 1
+    assert_tree_all_finite(
+        {"predicted_states": samples["f_predicted_states"]},
+        where="future-only rollout samples",
+    )
 
     # Keep a shape assertion in the same scenario (num_samples > 1, n_sim > 1).
     assert samples["f_predicted_states"].shape == (2, 2, len(predict_times), 2)
@@ -269,6 +298,14 @@ def test_predictive_simulator_only_times_has_n_sim_axis_sde(num_samples, n_sim):
     )
     with SDESimulator(n_simulations=n_sim):
         samples = predictive(jr.PRNGKey(0), predict_times=predict_times)
+    assert_tree_all_finite(
+        {
+            "times": samples["f_times"],
+            "states": samples["f_states"],
+            "observations": samples["f_observations"],
+        },
+        where="simulator-only SDE samples",
+    )
     assert samples["f_times"].shape == (num_samples, n_sim, len(predict_times))
     assert samples["f_states"].shape[0:3] == (num_samples, n_sim, len(predict_times))
     assert samples["f_observations"].shape[0:3] == (
@@ -291,6 +328,14 @@ def test_predictive_simulator_only_times_has_n_sim_axis_discrete(num_samples, n_
     )
     with DiscreteTimeSimulator(n_simulations=n_sim):
         samples = predictive(jr.PRNGKey(0), predict_times=predict_times)
+    assert_tree_all_finite(
+        {
+            "times": samples["f_times"],
+            "states": samples["f_states"],
+            "observations": samples["f_observations"],
+        },
+        where="simulator-only discrete samples",
+    )
     assert samples["f_times"].shape == (num_samples, n_sim, len(predict_times))
     assert samples["f_states"].shape[0:3] == (num_samples, n_sim, len(predict_times))
     assert samples["f_observations"].shape[0:3] == (
@@ -322,6 +367,14 @@ def test_predictive_simulator_only_times_has_n_sim_axis_ode(num_samples, n_sim):
             ctrl_times=ctrl_times,
             ctrl_values=ctrl_values,
         )
+    assert_tree_all_finite(
+        {
+            "times": samples["f_times"],
+            "states": samples["f_states"],
+            "observations": samples["f_observations"],
+        },
+        where="simulator-only ODE samples",
+    )
     assert samples["f_times"].shape == (num_samples, n_sim, len(predict_times))
     assert samples["f_states"].shape[0:3] == (num_samples, n_sim, len(predict_times))
     assert samples["f_observations"].shape[0:3] == (

--- a/tests/test_smoothers.py
+++ b/tests/test_smoothers.py
@@ -39,6 +39,10 @@ from tests.models import (
     discrete_time_lti_simplified_model,
     jumpy_controls_model_ode,
 )
+from tests.test_utils import (
+    assert_trace_sites_exist_and_field_all_finite,
+    assert_tree_all_finite,
+)
 
 
 def _gen_obs_discrete():
@@ -117,10 +121,24 @@ def test_compute_cuthbert_smoother_returns_observation_aligned_states(
     )
 
     assert jnp.ndim(marginal_loglik) == 0
+    assert_tree_all_finite(
+        {"marginal_loglik": marginal_loglik}, where="smoother output"
+    )
     if isinstance(smoother_config, PFSmootherConfig):
+        assert_tree_all_finite(
+            {
+                "particles": states.particles,
+                "log_weights": states.log_weights,
+            },
+            where="PF smoother states",
+        )
         assert states.particles.shape[0] == len(obs_times)
         assert states.log_weights.shape[0] == len(obs_times)
     else:
+        assert_tree_all_finite(
+            {"mean": states.mean, "chol_cov": states.chol_cov},
+            where="Gaussian smoother states",
+        )
         assert states.mean.shape[0] == len(obs_times)
         assert states.chol_cov.shape[0] == len(obs_times)
 
@@ -153,6 +171,15 @@ def test_predictive_smoother_discretetimesimulator_shapes():
     assert samples["f_predicted_times"].shape == (2, 2, len(predict_times))
     assert samples["f_smoothed_states_mean"].shape == (2, len(obs_times), 2)
     assert samples["f_smoothed_states_cov_diag"].shape == (2, len(obs_times), 2)
+    assert_tree_all_finite(
+        {
+            "predicted_states": samples["f_predicted_states"],
+            "predicted_times": samples["f_predicted_times"],
+            "smoothed_states_mean": samples["f_smoothed_states_mean"],
+            "smoothed_states_cov_diag": samples["f_smoothed_states_cov_diag"],
+        },
+        where="predictive discrete smoother samples",
+    )
     x0_keys = [k for k in samples if k.endswith("_x_0")]
     assert "f_1_x_0" in x0_keys
     assert "f_6_x_0" not in x0_keys
@@ -185,6 +212,14 @@ def test_predictive_smoother_odesimulator_shapes():
     assert samples["f_predicted_states"].shape == (2, 2, len(predict_times), 1)
     assert samples["f_predicted_times"].shape == (2, 2, len(predict_times))
     assert samples["f_smoothed_states_mean"].shape == (2, len(obs_times), 1)
+    assert_tree_all_finite(
+        {
+            "predicted_states": samples["f_predicted_states"],
+            "predicted_times": samples["f_predicted_times"],
+            "smoothed_states_mean": samples["f_smoothed_states_mean"],
+        },
+        where="predictive ODE smoother samples",
+    )
 
 
 @pytest.mark.parametrize(
@@ -472,6 +507,11 @@ def test_smoother_plate_batched_loglik_shape():
             )
 
     assert tr["f_marginal_loglik"]["value"].shape == (m,)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_marginal_loglik",
+        where="plate smoother trace",
+    )
 
 
 def test_smoother_plate_batched_continuous_initial_condition_discretized_rollout():
@@ -492,6 +532,13 @@ def test_smoother_plate_batched_continuous_initial_condition_discretized_rollout
     assert tr["f_marginal_loglik"]["value"].shape == (3,)
     assert tr["f_predicted_times"]["value"].shape == (3, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape == (3, 1, len(predict_times), 2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_marginal_loglik",
+        "f_predicted_times",
+        "f_predicted_states",
+        where="discretized plate smoother trace",
+    )
 
 
 def test_smoother_plate_batched_continuous_initial_condition_ct_rollout():
@@ -511,6 +558,13 @@ def test_smoother_plate_batched_continuous_initial_condition_ct_rollout():
     assert tr["f_marginal_loglik"]["value"].shape == (3,)
     assert tr["f_predicted_times"]["value"].shape == (3, 1, len(predict_times))
     assert tr["f_predicted_states"]["value"].shape == (3, 1, len(predict_times), 2)
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_marginal_loglik",
+        "f_predicted_times",
+        "f_predicted_states",
+        where="continuous plate smoother trace",
+    )
 
 
 def _explicit_rollout_metadata_model(predict_times=None):

--- a/tests/test_smoothers.py
+++ b/tests/test_smoothers.py
@@ -506,12 +506,12 @@ def test_smoother_plate_batched_loglik_shape():
                 m=m,
             )
 
-    assert tr["f_marginal_loglik"]["value"].shape == (m,)
     assert_trace_sites_exist_and_field_all_finite(
         tr,
         "f_marginal_loglik",
         where="plate smoother trace",
     )
+    assert tr["f_marginal_loglik"]["value"].shape == (m,)
 
 
 def test_smoother_plate_batched_continuous_initial_condition_discretized_rollout():
@@ -529,9 +529,6 @@ def test_smoother_plate_batched_continuous_initial_condition_discretized_rollout
                         M=3,
                     )
 
-    assert tr["f_marginal_loglik"]["value"].shape == (3,)
-    assert tr["f_predicted_times"]["value"].shape == (3, 1, len(predict_times))
-    assert tr["f_predicted_states"]["value"].shape == (3, 1, len(predict_times), 2)
     assert_trace_sites_exist_and_field_all_finite(
         tr,
         "f_marginal_loglik",
@@ -539,6 +536,9 @@ def test_smoother_plate_batched_continuous_initial_condition_discretized_rollout
         "f_predicted_states",
         where="discretized plate smoother trace",
     )
+    assert tr["f_marginal_loglik"]["value"].shape == (3,)
+    assert tr["f_predicted_times"]["value"].shape == (3, 1, len(predict_times))
+    assert tr["f_predicted_states"]["value"].shape == (3, 1, len(predict_times), 2)
 
 
 def test_smoother_plate_batched_continuous_initial_condition_ct_rollout():
@@ -555,9 +555,6 @@ def test_smoother_plate_batched_continuous_initial_condition_ct_rollout():
                     M=3,
                 )
 
-    assert tr["f_marginal_loglik"]["value"].shape == (3,)
-    assert tr["f_predicted_times"]["value"].shape == (3, 1, len(predict_times))
-    assert tr["f_predicted_states"]["value"].shape == (3, 1, len(predict_times), 2)
     assert_trace_sites_exist_and_field_all_finite(
         tr,
         "f_marginal_loglik",
@@ -565,6 +562,9 @@ def test_smoother_plate_batched_continuous_initial_condition_ct_rollout():
         "f_predicted_states",
         where="continuous plate smoother trace",
     )
+    assert tr["f_marginal_loglik"]["value"].shape == (3,)
+    assert tr["f_predicted_times"]["value"].shape == (3, 1, len(predict_times))
+    assert tr["f_predicted_states"]["value"].shape == (3, 1, len(predict_times), 2)
 
 
 def _explicit_rollout_metadata_model(predict_times=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,9 +9,103 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
+import pytest
 from numpyro.infer import Predictive
 
 _OUTPUT_MASTER_DIR: Path | None = None
+
+
+def assert_tree_all_finite(tree, *, where: str = "value") -> None:
+    """Assert that every floating-point leaf in a nested value is finite."""
+
+    def _walk(node, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                next_path = f"{path}.{key}" if path else f".{key}"
+                _walk(value, next_path)
+            return
+
+        if isinstance(node, (list, tuple)):
+            for index, value in enumerate(node):
+                _walk(value, f"{path}[{index}]")
+            return
+
+        try:
+            arr = jnp.asarray(node)
+        except Exception:
+            return
+
+        if not jnp.issubdtype(arr.dtype, jnp.inexact):
+            return
+
+        finite = jnp.isfinite(arr)
+        if bool(jnp.all(finite)):
+            return
+
+        bad_index = tuple(int(i) for i in np.argwhere(~np.asarray(finite))[0])
+        bad_value = np.asarray(arr)[bad_index]
+        location = f"{where}{path}" if path else where
+        raise AssertionError(
+            f"{location} contains non-finite value {bad_value} at index {bad_index}"
+        )
+
+    _walk(tree, "")
+
+
+def assert_trace_sites_exist_and_field_all_finite(
+    tr,
+    *site_names: str,
+    field: str = "value",
+    where: str,
+) -> None:
+    """Assert that selected trace sites exist and have a finite field."""
+
+    selected = {}
+    for site_name in site_names:
+        if site_name not in tr:
+            raise AssertionError(f"{where}: site {site_name!r} not found in trace")
+
+        site = tr[site_name]
+        if field not in site:
+            raise AssertionError(
+                f"{where}: site {site_name!r} does not contain field {field!r}"
+            )
+
+        selected[site_name] = site[field]
+
+    assert_tree_all_finite(
+        selected,
+        where=where,
+    )
+
+
+def test_assert_trace_sites_exist_and_field_all_finite_missing_site_error():
+    tr = {"present": {"value": jnp.array(1.0)}}
+
+    with pytest.raises(
+        AssertionError,
+        match=r"demo trace: site 'missing' not found in trace",
+    ):
+        assert_trace_sites_exist_and_field_all_finite(
+            tr,
+            "present",
+            "missing",
+            where="demo trace",
+        )
+
+
+def test_assert_trace_sites_exist_and_field_all_finite_nonfinite_error():
+    tr = {"present": {"value": jnp.array([1.0, jnp.nan])}}
+
+    with pytest.raises(
+        AssertionError,
+        match=r"demo trace\.present contains non-finite value nan at index \(1,\)",
+    ):
+        assert_trace_sites_exist_and_field_all_finite(
+            tr,
+            "present",
+            where="demo trace",
+        )
 
 
 def run_profile_likelihood(


### PR DESCRIPTION
This PR strengthens our test suite’s NaN detection by adding two shared helpers in [tests/test_utils.py](/Users/levinema/Projects/research/dynestyx/tests/test_utils.py): `assert_tree_all_finite(...)` for arrays / pytrees, and `assert_trace_sites_exist_and_field_all_finite(...)` for NumPyro traces. The trace helper now checks both that sites exist and that their selected field is finite, so a lot of trace-based tests got simpler and more consistent.

I also added a couple of focused tests for the new trace helper itself, covering both failure modes: a missing trace site and a non-finite trace value. Then I applied the helper to the highest-priority simulator / filter / smoother smoke tests that were previously mostly shape-only.

In the process, we found a real hidden NaN issue in the nested-plate discrete path: nested plate discrete conditioning currently leaves NaNs in `f_states`. That behavior is now captured with a strict `xfail`, and the related nested Dirac rollout case is also marked `xfail` since it hits the same underlying nested-plate NaN problem.