### PR TITLE
Fix Frozen Diffusion Coefficient Array; Properly Plate Diffusion Coefficients

### DIFF
--- a/dynestyx/inference/plate_utils.py
+++ b/dynestyx/inference/plate_utils.py
@@ -3,9 +3,12 @@ import jax.numpy as jnp
 import numpyro
 from jaxtyping import Array, Shaped
 
+from dynestyx.models import Diffusion
 from dynestyx.utils import (
     _array_has_plate_dims,
+    _diffusion_coefficient_is_plate_batched,
     _dist_has_plate_batch_dims,
+    _is_opaque_plate_leaf,
     _leaf_is_plate_batched,
 )
 
@@ -21,18 +24,24 @@ def _make_plate_in_axes(tree, plate_shapes: tuple[int, ...]):
     ``.mean`` / ``.sample`` / ``.log_prob`` re-expand to the full plate shape).
     """
 
-    def _is_distribution_leaf(node) -> bool:
-        return isinstance(node, numpyro.distributions.Distribution)
-
     def _axis(path, leaf):
         if isinstance(leaf, numpyro.distributions.Distribution):
             return None
+        # Only constant-coefficient diffusions are opaque leaves (see
+        # ``_is_opaque_plate_leaf``); a callable coefficient is recursed into, so
+        # its array fields are vmapped generically by the branch below.
+        if isinstance(leaf, Diffusion):
+            return (
+                0
+                if _diffusion_coefficient_is_plate_batched(leaf, plate_shapes)
+                else None
+            )
         return 0 if _leaf_is_plate_batched(leaf, plate_shapes, path=path) else None
 
     return jax.tree_util.tree_map_with_path(
         _axis,
         tree,
-        is_leaf=_is_distribution_leaf,
+        is_leaf=_is_opaque_plate_leaf,
     )
 
 

--- a/dynestyx/models/core.py
+++ b/dynestyx/models/core.py
@@ -457,7 +457,7 @@ class StochasticContinuousTimeStateEvolution(ContinuousTimeStateEvolution):
     discretizers, and inference backends.
     """
 
-    diffusion: Diffusion = eqx.field(static=True, kw_only=True)
+    diffusion: Diffusion = eqx.field(kw_only=True)
 
     def __init__(
         self,

--- a/dynestyx/models/diffusions.py
+++ b/dynestyx/models/diffusions.py
@@ -62,6 +62,27 @@ class Diffusion(eqx.Module):
         self.bm_dim = None if bm_dim is None else int(bm_dim)
         self._validate_init()
 
+    @property
+    def coefficient_event_rank(self) -> int | None:
+        """The per-member event rank of a constant coefficient (``None`` if callable).
+
+        The event rank is the number of trailing axes that make up one member's
+        coefficient, independent of any leading plate batch axes (``FullDiffusion``
+        is matrix-valued so rank 2, ``DiagonalDiffusion`` vector-valued so rank 1,
+        ``ScalarDiffusion`` scalar so rank 0). It lets the plate machinery tell a
+        shared coefficient from a genuinely per-member one even when its shape
+        coincides with the plate sizes. ``None`` for callable coefficients, whose
+        value is not a sliceable pytree leaf.
+
+        This is a derived property rather than a stored field beacuse of interactions
+        with effectful and equinox.
+        """
+        raise NotImplementedError(
+            "Please don't construct `Diffusion` directly; instead instantiate one "
+            "of its subclasses (e.g., `FullDiffusion`, `DiagonalDiffusion`, or "
+            "`ScalarDiffusion`)"
+        )
+
     def evaluate_value(
         self,
         *,
@@ -199,6 +220,11 @@ class FullDiffusion(Diffusion):
         if shape is not None and self.bm_dim is None:
             self.bm_dim = int(shape[-1])
 
+    @property
+    def coefficient_event_rank(self) -> int | None:
+        # Matrix-valued coefficient with trailing shape (..., state_dim, bm_dim).
+        return None if self._constant_shape() is None else 2
+
     def resolve_metadata(
         self,
         *,
@@ -279,6 +305,11 @@ class DiagonalDiffusion(Diffusion):
                 "with trailing shape (..., state_dim). "
                 f"Got shape {shape}."
             )
+
+    @property
+    def coefficient_event_rank(self) -> int | None:
+        # Vector-valued coefficient with trailing shape (..., state_dim).
+        return None if self._constant_shape() is None else 1
 
     def resolve_metadata(
         self,
@@ -366,6 +397,15 @@ class ScalarDiffusion(Diffusion):
                 "shape (..., 1). "
                 f"Got shape {shape}."
             )
+
+    @property
+    def coefficient_event_rank(self) -> int | None:
+        # Scalar coefficient: rank 0 when stored as a bare scalar ``()``, or rank 1
+        # when stored with an explicit trailing event axis ``(..., 1)``.
+        shape = self._constant_shape()
+        if shape is None:
+            return None
+        return 1 if (len(shape) > 0 and shape[-1] == 1) else 0
 
     def resolve_metadata(
         self,

--- a/dynestyx/simulators.py
+++ b/dynestyx/simulators.py
@@ -26,6 +26,7 @@ from dynestyx.inference.plate_utils import (
 )
 from dynestyx.models import (
     DeterministicContinuousTimeStateEvolution,
+    Diffusion,
     DiracIdentityObservation,
     DiscreteTimeStateEvolution,
     DynamicalModel,
@@ -37,9 +38,11 @@ from dynestyx.solvers import solve_ode, solve_sde
 from dynestyx.types import FunctionOfTime, as_scalar_time_array
 from dynestyx.utils import (
     _build_control_path,
+    _diffusion_coefficient_is_plate_batched,
     _dist_has_plate_batch_dims,
     _get_val_or_None,
     _has_any_batched_plate_source,
+    _is_opaque_plate_leaf,
     _leaf_is_plate_batched,
     _validate_site_sorting,
 )
@@ -104,10 +107,17 @@ def _slice_tree_for_plate_member(tree, plate_shapes: tuple[int, ...], plate_idx)
     sliced separately by ``_slice_dist_for_plate_member``.
     """
 
-    def _is_distribution_leaf(node) -> bool:
-        return isinstance(node, numpyro.distributions.Distribution)
-
     def _slice_leaf(path, leaf):
+        # Only constant-coefficient diffusions are opaque leaves (see
+        # ``_is_opaque_plate_leaf``), so indexing the coefficient by ``plate_idx``
+        # is well-defined; a callable coefficient is recursed into and its array
+        # fields are sliced generically by the branch below.
+        if isinstance(leaf, Diffusion):
+            if _diffusion_coefficient_is_plate_batched(leaf, plate_shapes):
+                return eqx.tree_at(
+                    lambda d: d.coefficient, leaf, leaf.coefficient[plate_idx]
+                )
+            return leaf
         if _leaf_is_plate_batched(leaf, plate_shapes, path=path):
             return leaf[plate_idx]
         return leaf
@@ -115,7 +125,7 @@ def _slice_tree_for_plate_member(tree, plate_shapes: tuple[int, ...], plate_idx)
     return jax.tree_util.tree_map_with_path(
         _slice_leaf,
         tree,
-        is_leaf=_is_distribution_leaf,
+        is_leaf=_is_opaque_plate_leaf,
     )
 
 

--- a/dynestyx/utils.py
+++ b/dynestyx/utils.py
@@ -12,7 +12,7 @@ from cd_dynamax import ContDiscreteNonlinearSSM as CDNLSSM
 from jax import Array, lax
 from jaxtyping import Real, Shaped
 
-from dynestyx.models import DynamicalModel
+from dynestyx.models import Diffusion, DynamicalModel
 
 
 def flatten_draws(arr: Shaped[Array, "..."]) -> Shaped[Array, "..."]:
@@ -159,6 +159,56 @@ def _leaf_is_plate_batched(leaf, plate_shapes: tuple[int, ...], path=()) -> bool
     return suffix_ndim == 0 or suffix_ndim >= 2
 
 
+def _diffusion_coefficient_is_plate_batched(
+    diffusion: Diffusion, plate_shapes: tuple[int, ...]
+) -> bool:
+    """Return True if a diffusion's *constant* coefficient is laid out per-member.
+
+    True means the coefficient is a constant array whose leading axes are exactly
+    ``plate_shapes`` followed by its intrinsic event axes — i.e. it should be
+    sliced (``coefficient[plate_idx]``) or vmapped (``in_axes=0``) as an opaque
+    unit. Classification uses the coefficient's event rank (a static property of
+    the ``Diffusion``) rather than a raw suffix-rank heuristic, so a *shared*
+    matrix/vector coefficient whose shape happens to coincide with the plate sizes
+    (e.g. a ``(state_dim, bm_dim)`` matrix under nested plates ``(state_dim,
+    bm_dim)``) is correctly treated as shared.
+
+    Returns False for a callable coefficient: such a coefficient is not classified
+    as a unit here. The plate consumers instead recurse into a callable
+    ``eqx.Module`` coefficient and slice/vmap its per-member array fields
+    generically (a plain closure that captures per-member parameters remains the
+    unsupported sharp edge; see the ``dsx.plate`` docstring).
+    """
+    event_rank = diffusion.coefficient_event_rank
+    if event_rank is None:
+        return False
+    shape = diffusion._constant_shape()
+    assert shape is not None
+    n_plates = len(plate_shapes)
+    return len(shape) == n_plates + event_rank and tuple(shape[:n_plates]) == tuple(
+        plate_shapes
+    )
+
+
+def _is_opaque_plate_leaf(node) -> bool:
+    """Shared ``is_leaf`` predicate for plate classification, slicing, and vmap.
+
+    A ``Diffusion`` with a *constant* coefficient is an opaque unit (classified by
+    its own ``coefficient_event_rank``, since a path-blind shape check cannot
+    disambiguate it). A *callable* coefficient may be an ``eqx.Module`` carrying
+    per-member array fields, so the tree must recurse into it and handle those
+    fields generically. NumPyro distributions are always opaque. The three
+    consumers (:func:`_has_any_batched_plate_source`,
+    ``inference.plate_utils._make_plate_in_axes``,
+    ``simulators._slice_tree_for_plate_member``) must share this one predicate so
+    a callable diffusion is never seen as batched by the slicer/vmap while being
+    invisible to the alignment guard.
+    """
+    if isinstance(node, Diffusion):
+        return not callable(node.coefficient)
+    return isinstance(node, numpyro.distributions.Distribution)
+
+
 def _dist_has_plate_batch_dims(dist_obj, plate_shapes: tuple[int, ...]) -> bool:
     """Return True when a distribution's leading ``batch_shape`` matches plates."""
     if dist_obj is None or not hasattr(dist_obj, "batch_shape"):
@@ -183,10 +233,17 @@ def _has_any_batched_plate_source(
     """Return True if dynamics, arrays, or distributions carry plate axes."""
     for path, leaf in jax.tree_util.tree_flatten_with_path(
         dynamics,
-        is_leaf=lambda node: isinstance(node, numpyro.distributions.Distribution),
+        is_leaf=_is_opaque_plate_leaf,
     )[0]:
         if isinstance(leaf, numpyro.distributions.Distribution):
             if _dist_has_plate_batch_dims(leaf, plate_shapes):
+                return True
+            continue
+        # Only constant-coefficient diffusions are opaque leaves here; a callable
+        # coefficient is recursed into, so its per-member array fields reach the
+        # generic ``_leaf_is_plate_batched`` branch below.
+        if isinstance(leaf, Diffusion):
+            if _diffusion_coefficient_is_plate_batched(leaf, plate_shapes):
                 return True
             continue
         if _leaf_is_plate_batched(leaf, plate_shapes, path=path):

--- a/tests/test_hierarchical_simulator_discretizer_smokes.py
+++ b/tests/test_hierarchical_simulator_discretizer_smokes.py
@@ -792,6 +792,41 @@ def test_nested_plate_discretizer_filter_rollout_shapes():
     assert jnp.array_equal(tr["f_predicted_times"]["value"][0, 0, 0], predict_times)
 
 
+def test_nested_plate_continuous_sde_enkf_shapes():
+    # Exercises the vmap (continuous-time filter) path with the nested SHARED
+    # (2, 2) diffusion coefficient whose shape collides with the (2, 2) plate
+    # sizes; the coefficient must be classified as shared (not sliced/vmapped).
+    obs_times = jnp.linspace(0.0, 1.5, 4)
+
+    with SDESimulator():
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(31)):
+            _nested_plate_continuous_for_discretizer_model(
+                predict_times=obs_times, G=2, M=2
+            )
+    obs = tr["f_observations"]["value"][:, :, 0]
+
+    with Filter(
+        filter_config=ContinuousTimeEnKFConfig(
+            n_particles=8,
+            crn_seed=jr.PRNGKey(32),
+        )
+    ):
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(33)):
+            _nested_plate_continuous_for_discretizer_model(
+                obs_times=obs_times,
+                obs_values=obs,
+                G=2,
+                M=2,
+            )
+
+    assert_trace_sites_exist_and_field_all_finite(
+        tr,
+        "f_marginal_loglik",
+        where="nested plate continuous SDE EnKF trace",
+    )
+    assert tr["f_marginal_loglik"]["value"].shape == (2, 2)
+
+
 def test_plate_discrete_dirac_forward_and_conditioning_shapes():
     t = jnp.arange(4.0)
 

--- a/tests/test_plate_vector_initial_mean_continuous_drift_diffusion.py
+++ b/tests/test_plate_vector_initial_mean_continuous_drift_diffusion.py
@@ -10,7 +10,7 @@ from jax import Array
 from numpyro.handlers import seed, trace
 
 import dynestyx as dsx
-from dynestyx import DiscreteTimeSimulator, Discretizer, Filter, SDESimulator
+from dynestyx import DiscreteTimeSimulator, Discretizer, Filter, SDESimulator, Smoother
 from dynestyx.inference.filter_configs import (
     ContinuousTimeDPFConfig,
     ContinuousTimeEKFConfig,
@@ -20,6 +20,7 @@ from dynestyx.inference.filter_configs import (
     EnKFConfig,
     PFConfig,
 )
+from dynestyx.inference.smoother_configs import ContinuousTimeEKFSmootherConfig
 from dynestyx.models import (
     ContinuousTimeStateEvolution,
     DiagonalDiffusion,
@@ -28,6 +29,8 @@ from dynestyx.models import (
     LinearGaussianObservation,
     ScalarDiffusion,
 )
+from dynestyx.simulators import _slice_tree_for_plate_member
+from dynestyx.utils import _has_any_batched_plate_source
 
 
 class _AlphaDrift(eqx.Module):
@@ -326,3 +329,501 @@ def test_manual_continuous_model_shared_parameters_ct_filters(
             )
 
     assert tr["f_marginal_loglik"]["value"].shape == (3,)
+
+
+# ---------------------------------------------------------------------------
+# Per-member (genuinely batched) diffusion coefficients.
+#
+# These pin the behavior that the diffusion coefficient is a real, plate-batched
+# pytree leaf (no longer a `static` field) and that the plate machinery slices /
+# vmaps it per member by its intrinsic event rank. Before this fix, a per-member
+# coefficient was hidden in the model's static aux-data, so per-member diffusion
+# silently did not work (and a continuous-time filter over it crashed).
+# ---------------------------------------------------------------------------
+
+
+def _per_member_diffusion_model(
+    *,
+    sigma_vals: Array,
+    diffusion_form: str = "full",
+    obs_times=None,
+    obs_values=None,
+    predict_times=None,
+):
+    """Single-plate model whose diffusion scale varies deterministically per member."""
+    state_dim = 2
+    M = sigma_vals.shape[0]
+    initial_mean = jnp.broadcast_to(jnp.array([0.1, 0.05]), (M, state_dim))
+    initial_cov = 0.15 * jnp.eye(state_dim)
+    obs_cov = (0.08**2) * jnp.eye(state_dim)
+
+    with dsx.plate("trajectories", M):
+        dynamics = DynamicalModel(
+            control_dim=0,
+            initial_condition=dist.MultivariateNormal(
+                loc=initial_mean,
+                covariance_matrix=initial_cov,
+            ),
+            state_evolution=ContinuousTimeStateEvolution(
+                drift=_AlphaDrift(alpha=jnp.full((M,), 0.4)),
+                diffusion=_make_diffusion(diffusion_form, sigma_vals),
+            ),
+            observation_model=LinearGaussianObservation(
+                H=jnp.eye(state_dim),
+                R=obs_cov,
+            ),
+        )
+        dsx.sample(
+            "f",
+            dynamics,
+            obs_times=obs_times,
+            obs_values=obs_values,
+            predict_times=predict_times,
+        )
+
+
+def _shared_obs_across_members(M, obs_times, diffusion_form):
+    """Generate one observation trajectory and broadcast it identically to M members.
+
+    Sharing identical data across members isolates the diffusion coefficient as the
+    only thing that varies per member, so any spread in per-member marginal
+    log-likelihood is attributable solely to per-member diffusion being used.
+    """
+    with SDESimulator():
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(101)):
+            _per_member_diffusion_model(
+                sigma_vals=jnp.full((M,), 0.2),
+                diffusion_form=diffusion_form,
+                predict_times=obs_times,
+            )
+    single = tr["f_observations"]["value"][0, 0]  # (T, obs_dim) from member 0
+    return jnp.broadcast_to(single, (M,) + single.shape)
+
+
+@pytest.mark.parametrize("diffusion_form", ["scalar", "diag", "full"])
+def test_per_member_diffusion_ct_enkf_uses_per_member_sigma(diffusion_form):
+    obs_times = jnp.linspace(0.0, 0.6, 7)
+    M = 3
+    obs_values = _shared_obs_across_members(M, obs_times, diffusion_form)
+
+    sigma_vals = jnp.array([0.05, 0.25, 0.8])
+    with Filter(
+        filter_config=ContinuousTimeEnKFConfig(
+            n_particles=16,
+            crn_seed=jr.PRNGKey(102),
+        )
+    ):
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(103)):
+            _per_member_diffusion_model(
+                sigma_vals=sigma_vals,
+                diffusion_form=diffusion_form,
+                obs_times=obs_times,
+                obs_values=obs_values,
+            )
+
+    loglik = tr["f_marginal_loglik"]["value"]
+    assert loglik.shape == (M,)
+    assert jnp.all(jnp.isfinite(loglik))
+    # Identical data + distinct per-member sigma => distinct marginal logliks.
+    # Equal logliks would mean a single (shared) coefficient leaked to all members.
+    assert float(jnp.ptp(loglik)) > 1e-2
+
+
+def test_per_member_diffusion_discretizer_filter_uses_per_member_sigma():
+    obs_times = jnp.arange(6.0)
+    M = 3
+    # Deterministic discretized observations, shared identically across members.
+    with DiscreteTimeSimulator():
+        with Discretizer():
+            with trace() as tr, seed(rng_seed=jr.PRNGKey(104)):
+                _per_member_diffusion_model(
+                    sigma_vals=jnp.full((M,), 0.2),
+                    diffusion_form="full",
+                    predict_times=obs_times,
+                )
+    single = tr["f_observations"]["value"][0, 0]
+    obs_values = jnp.broadcast_to(single, (M,) + single.shape)
+
+    sigma_vals = jnp.array([0.05, 0.25, 0.8])
+    with Filter(filter_config=EKFConfig(filter_source="cuthbert")):
+        with Discretizer():
+            with trace() as tr, seed(rng_seed=jr.PRNGKey(105)):
+                _per_member_diffusion_model(
+                    sigma_vals=sigma_vals,
+                    diffusion_form="full",
+                    obs_times=obs_times,
+                    obs_values=obs_values,
+                )
+
+    loglik = tr["f_marginal_loglik"]["value"]
+    assert loglik.shape == (M,)
+    assert jnp.all(jnp.isfinite(loglik))
+    # The discretizer wraps the diffusion at `state_evolution.cte.diffusion`; the
+    # per-member coefficient must still be vmapped per member through that wrapper.
+    assert float(jnp.ptp(loglik)) > 1e-2
+
+
+def _nested_per_member_diffusion_model(
+    *,
+    sigma_vals: Array,
+    obs_times=None,
+    obs_values=None,
+    predict_times=None,
+):
+    """Nested-plate (trajectories x groups) model with per-member diffusion."""
+    state_dim = 2
+    M, G = sigma_vals.shape
+    initial_mean = jnp.broadcast_to(jnp.array([0.1, 0.05]), (M, G, state_dim))
+    initial_cov = 0.15 * jnp.eye(state_dim)
+    obs_cov = (0.08**2) * jnp.eye(state_dim)
+    base = jnp.array([[1.0, 0.0], [0.2, 0.7]])
+
+    with dsx.plate("groups", G):
+        with dsx.plate("trajectories", M):
+            coeff = sigma_vals[..., None, None] * base  # (M, G, state_dim, state_dim)
+            dynamics = DynamicalModel(
+                control_dim=0,
+                initial_condition=dist.MultivariateNormal(
+                    loc=initial_mean,
+                    covariance_matrix=initial_cov,
+                ),
+                state_evolution=ContinuousTimeStateEvolution(
+                    drift=_AlphaDrift(alpha=jnp.full((M, G), 0.4)),
+                    diffusion=FullDiffusion(coeff),
+                ),
+                observation_model=LinearGaussianObservation(
+                    H=jnp.eye(state_dim),
+                    R=obs_cov,
+                ),
+            )
+            dsx.sample(
+                "f",
+                dynamics,
+                obs_times=obs_times,
+                obs_values=obs_values,
+                predict_times=predict_times,
+            )
+
+
+def test_nested_per_member_diffusion_ct_enkf_uses_per_member_sigma():
+    obs_times = jnp.linspace(0.0, 0.6, 7)
+    # M, G distinct from state_dim/obs_dim (2) so the shared (2, 2) matrices
+    # (H, base, covariances) do not collide with the plate sizes.
+    M, G = 3, 2
+    with SDESimulator():
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(106)):
+            _nested_per_member_diffusion_model(
+                sigma_vals=jnp.full((M, G), 0.2),
+                predict_times=obs_times,
+            )
+    single = tr["f_observations"]["value"][0, 0, 0]  # (T, obs_dim)
+    obs_values = jnp.broadcast_to(single, (M, G) + single.shape)
+
+    sigma_vals = jnp.array([[0.05, 0.1], [0.4, 0.8], [0.15, 0.6]])
+    with Filter(
+        filter_config=ContinuousTimeEnKFConfig(
+            n_particles=16,
+            crn_seed=jr.PRNGKey(107),
+        )
+    ):
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(108)):
+            _nested_per_member_diffusion_model(
+                sigma_vals=sigma_vals,
+                obs_times=obs_times,
+                obs_values=obs_values,
+            )
+
+    loglik = tr["f_marginal_loglik"]["value"]
+    assert loglik.shape == (M, G)
+    assert jnp.all(jnp.isfinite(loglik))
+    # Nested vmap must strip both plate axes from the (M, G, 2, 2) coefficient.
+    assert float(jnp.ptp(loglik)) > 1e-2
+
+
+# Note: a separate, pre-existing ambiguity affects raw matrix-valued model fields
+# (e.g. an observation matrix `H` of shape (state_dim, obs_dim)) whose shape
+# coincides with the plate sizes; that is independent of the diffusion coefficient
+# handled here, which is why this nested test uses non-colliding plate sizes.
+
+
+def _sde_model_with_diffusion(diffusion):
+    """Minimal single-trajectory SDE model wrapping a given diffusion."""
+    state_dim = 2
+    return DynamicalModel(
+        control_dim=0,
+        initial_condition=dist.MultivariateNormal(
+            loc=jnp.zeros(state_dim),
+            covariance_matrix=jnp.eye(state_dim),
+        ),
+        state_evolution=ContinuousTimeStateEvolution(
+            drift=_AlphaDrift(alpha=jnp.array(0.4)),
+            diffusion=diffusion,
+        ),
+        observation_model=LinearGaussianObservation(
+            H=jnp.eye(state_dim),
+            R=0.1 * jnp.eye(state_dim),
+        ),
+    )
+
+
+def test_slice_tree_selects_per_member_diffusion_coefficient():
+    # Per-member, single plate (M=3): coefficient (3, 2, 2) -> member's (2, 2).
+    coeff = jnp.arange(3 * 2 * 2, dtype=float).reshape(3, 2, 2)
+    se = _sde_model_with_diffusion(FullDiffusion(coeff)).state_evolution
+    sliced = _slice_tree_for_plate_member(se, (3,), (1,))
+    assert sliced.diffusion.coefficient.shape == (2, 2)
+    assert jnp.array_equal(sliced.diffusion.coefficient, coeff[1])
+
+    # Per-member, nested plate (M, G) = (2, 2): coefficient (2, 2, 2, 2).
+    coeff_n = jnp.arange(2 * 2 * 2 * 2, dtype=float).reshape(2, 2, 2, 2)
+    se_n = _sde_model_with_diffusion(FullDiffusion(coeff_n)).state_evolution
+    sliced_n = _slice_tree_for_plate_member(se_n, (2, 2), (1, 0))
+    assert sliced_n.diffusion.coefficient.shape == (2, 2)
+    assert jnp.array_equal(sliced_n.diffusion.coefficient, coeff_n[1, 0])
+
+    # Shared (2, 2) under a single plate (3,): NOT sliced.
+    shared = 0.2 * jnp.eye(2)
+    se_s = _sde_model_with_diffusion(FullDiffusion(shared)).state_evolution
+    sliced_s = _slice_tree_for_plate_member(se_s, (3,), (1,))
+    assert jnp.array_equal(sliced_s.diffusion.coefficient, shared)
+
+    # Shape-collision regression: a shared (2, 2) coefficient under nested plates
+    # (2, 2) must stay shared, not be sliced down to a scalar.
+    se_c = _sde_model_with_diffusion(FullDiffusion(shared)).state_evolution
+    sliced_c = _slice_tree_for_plate_member(se_c, (2, 2), (1, 1))
+    assert sliced_c.diffusion.coefficient.shape == (2, 2)
+    assert jnp.array_equal(sliced_c.diffusion.coefficient, shared)
+
+
+def test_sde_model_build_emits_no_static_array_warning(recwarn):
+    _ = _sde_model_with_diffusion(FullDiffusion(0.3 * jnp.eye(2)))
+    static_warnings = [
+        w for w in recwarn.list if "being set as static" in str(w.message)
+    ]
+    assert not static_warnings, [str(w.message) for w in static_warnings]
+
+
+class _PerMemberScaledDiffusion(eqx.Module):
+    """Callable (time-varying) diffusion coefficient with a per-member array field.
+
+    The diffusion analogue of ``_AlphaDrift``: storing the per-member ``scale`` as
+    an array field of an ``eqx.Module`` keeps it a sliceable pytree leaf, so the
+    plate machinery recurses into the callable coefficient and gives each member
+    its own scale (a plain closure would hide it).
+    """
+
+    scale: Array
+
+    def __call__(self, x, u, t):
+        base = jnp.array([[1.0, 0.0], [0.2, 0.7]])
+        return self.scale[..., None, None] * jnp.exp(-0.1 * t) * base
+
+
+def test_slice_tree_recurses_into_callable_module_diffusion():
+    # A per-member callable coefficient (an eqx.Module with a (M,) field) is sliced
+    # by recursing into the callable, not by treating the diffusion as opaque.
+    scale = jnp.array([0.1, 0.2, 0.3])
+    se = _sde_model_with_diffusion(
+        FullDiffusion(_PerMemberScaledDiffusion(scale=scale), bm_dim=2)
+    ).state_evolution
+    sliced = _slice_tree_for_plate_member(se, (3,), (1,))
+    assert sliced.diffusion.coefficient.scale.shape == ()
+    assert float(sliced.diffusion.coefficient.scale) == float(scale[1])
+
+    # A shared callable coefficient (plain lambda) carries no array leaves and is
+    # left untouched (correctly treated as shared, never indexed).
+    se_shared = _sde_model_with_diffusion(
+        FullDiffusion(lambda x, u, t: 0.2 * jnp.eye(2), bm_dim=2)
+    ).state_evolution
+    sliced_shared = _slice_tree_for_plate_member(se_shared, (3,), (1,))
+    assert callable(sliced_shared.diffusion.coefficient)
+
+
+def _per_member_callable_diffusion_model(
+    *,
+    scale_vals: Array,
+    obs_times=None,
+    obs_values=None,
+    predict_times=None,
+):
+    """Single-plate model whose callable diffusion has a per-member scale field."""
+    state_dim = 2
+    M = scale_vals.shape[0]
+    initial_mean = jnp.broadcast_to(jnp.array([0.1, 0.05]), (M, state_dim))
+    obs_cov = (0.08**2) * jnp.eye(state_dim)
+
+    with dsx.plate("trajectories", M):
+        dynamics = DynamicalModel(
+            control_dim=0,
+            initial_condition=dist.MultivariateNormal(
+                loc=initial_mean,
+                covariance_matrix=0.15 * jnp.eye(state_dim),
+            ),
+            state_evolution=ContinuousTimeStateEvolution(
+                drift=_AlphaDrift(alpha=jnp.full((M,), 0.4)),
+                diffusion=FullDiffusion(
+                    _PerMemberScaledDiffusion(scale=scale_vals), bm_dim=state_dim
+                ),
+            ),
+            observation_model=LinearGaussianObservation(
+                H=jnp.eye(state_dim),
+                R=obs_cov,
+            ),
+        )
+        dsx.sample(
+            "f",
+            dynamics,
+            obs_times=obs_times,
+            obs_values=obs_values,
+            predict_times=predict_times,
+        )
+
+
+def test_per_member_callable_module_diffusion_ct_enkf_uses_per_member_scale():
+    obs_times = jnp.linspace(0.0, 0.6, 7)
+    M = 3
+    with SDESimulator():
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(140)):
+            _per_member_callable_diffusion_model(
+                scale_vals=jnp.full((M,), 0.2),
+                predict_times=obs_times,
+            )
+    single = tr["f_observations"]["value"][0, 0]
+    obs_values = jnp.broadcast_to(single, (M,) + single.shape)
+
+    scale_vals = jnp.array([0.05, 0.25, 0.8])
+    with Filter(
+        filter_config=ContinuousTimeEnKFConfig(
+            n_particles=16,
+            crn_seed=jr.PRNGKey(141),
+        )
+    ):
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(142)):
+            _per_member_callable_diffusion_model(
+                scale_vals=scale_vals,
+                obs_times=obs_times,
+                obs_values=obs_values,
+            )
+
+    loglik = tr["f_marginal_loglik"]["value"]
+    assert loglik.shape == (M,)
+    assert jnp.all(jnp.isfinite(loglik))
+    # The per-member scale lives inside a callable coefficient; identical data plus
+    # distinct per-member scales must still yield distinct marginal logliks.
+    assert float(jnp.ptp(loglik)) > 1e-2
+
+
+def test_callable_diffusion_is_recognized_as_sole_plate_source():
+    # Regression: the plate-source detector must agree with the slicer/vmap. A
+    # callable eqx.Module diffusion (per-member ``scale``) as the ONLY plate-batched
+    # source (shared initial condition, shared drift, non-colliding obs) must be
+    # detected; otherwise the simulator/filter/smoother alignment guards spuriously
+    # reject a model the slicers can handle.
+    model = _sde_model_with_diffusion(
+        FullDiffusion(_PerMemberScaledDiffusion(scale=jnp.array([0.05, 0.25, 0.8])))
+    )
+    assert _has_any_batched_plate_source(model, (3,)) is True
+    # The slicer agrees: member 1's scale is selected.
+    sliced = _slice_tree_for_plate_member(model.state_evolution, (3,), (1,))
+    assert float(sliced.diffusion.coefficient.scale) == 0.25
+    # A shared callable carries no per-member field, so it is not a plate source.
+    shared = _sde_model_with_diffusion(FullDiffusion(lambda x, u, t: 0.2 * jnp.eye(2)))
+    assert _has_any_batched_plate_source(shared, (3,)) is False
+
+
+def _shared_ic_callable_diffusion_model(
+    *,
+    scale_vals: Array,
+    obs_times=None,
+    obs_values=None,
+    predict_times=None,
+):
+    """Plate model whose ONLY per-member source is a callable diffusion field.
+
+    Initial condition, drift, and observation model are all shared, so the
+    callable coefficient's per-member ``scale`` is the sole plate-batched source —
+    the exact case that trips an alignment guard inconsistent with the slicers.
+    """
+    state_dim = 2
+    M = scale_vals.shape[0]
+    obs_cov = (0.08**2) * jnp.eye(state_dim)
+    with dsx.plate("trajectories", M):
+        dynamics = DynamicalModel(
+            control_dim=0,
+            initial_condition=dist.MultivariateNormal(
+                loc=jnp.array([0.1, 0.05]),
+                covariance_matrix=0.15 * jnp.eye(state_dim),
+            ),
+            state_evolution=ContinuousTimeStateEvolution(
+                drift=_AlphaDrift(alpha=jnp.asarray(0.4)),
+                diffusion=FullDiffusion(
+                    _PerMemberScaledDiffusion(scale=scale_vals), bm_dim=state_dim
+                ),
+            ),
+            observation_model=LinearGaussianObservation(
+                H=jnp.eye(state_dim),
+                R=obs_cov,
+            ),
+        )
+        dsx.sample(
+            "f",
+            dynamics,
+            obs_times=obs_times,
+            obs_values=obs_values,
+            predict_times=predict_times,
+        )
+
+
+def test_callable_diffusion_sole_plate_source_simulates_and_filters():
+    M = 3
+    times = jnp.linspace(0.0, 0.6, 6)
+    # Forward simulation: the plated simulator gate must not reject the model.
+    with SDESimulator():
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(150)):
+            _shared_ic_callable_diffusion_model(
+                scale_vals=jnp.array([0.05, 0.25, 0.8]),
+                predict_times=times,
+            )
+    states = tr["f_states"]["value"]
+    assert states.shape[0] == M
+    assert jnp.all(jnp.isfinite(states))
+
+    # Filtering with SHARED observations: the only plate source is the callable
+    # diffusion, so the alignment guard must accept it.
+    obs_values = tr["f_observations"]["value"][0, 0]  # (T, obs_dim), shared
+    with Filter(
+        filter_config=ContinuousTimeEnKFConfig(n_particles=16, crn_seed=jr.PRNGKey(151))
+    ):
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(152)):
+            _shared_ic_callable_diffusion_model(
+                scale_vals=jnp.array([0.05, 0.25, 0.8]),
+                obs_times=times,
+                obs_values=obs_values,
+            )
+    loglik = tr["f_marginal_loglik"]["value"]
+    assert loglik.shape == (M,)
+    assert jnp.all(jnp.isfinite(loglik))
+    assert float(jnp.ptp(loglik)) > 1e-2
+
+
+def test_per_member_diffusion_ct_smoother_uses_per_member_sigma():
+    # Smoothers share _make_plate_in_axes / the alignment guard with filters; pin
+    # per-member diffusion through the continuous-time (CD-EKS) smoother vmap path.
+    obs_times = jnp.linspace(0.0, 0.6, 7)
+    M = 3
+    obs_values = _shared_obs_across_members(M, obs_times, "full")
+
+    sigma_vals = jnp.array([0.05, 0.25, 0.8])
+    with Smoother(smoother_config=ContinuousTimeEKFSmootherConfig()):
+        with trace() as tr, seed(rng_seed=jr.PRNGKey(160)):
+            _per_member_diffusion_model(
+                sigma_vals=sigma_vals,
+                diffusion_form="full",
+                obs_times=obs_times,
+                obs_values=obs_values,
+            )
+
+    loglik = tr["f_marginal_loglik"]["value"]
+    assert loglik.shape == (M,)
+    assert jnp.all(jnp.isfinite(loglik))
+    assert float(jnp.ptp(loglik)) > 1e-2


### PR DESCRIPTION
This PR fixes two things:
- An issue with an accidentally-static diffusion field in `StochasticContinuousTimeStateEvolution` (thanks @rfl-urbaniak for pointing this out!)
- A resulting bug with shared diffusion coefficients under plating, that the preceding bug accidentally masked.

For the latter, the issue is that plate dimensions with scalar/vector quantities can cause ambiguities with plate dimensions, since we still don't annotate event dimensions. This now treats diffusions with constant coefficients as opaque leaves when plating or indexing, and uses an annotated event dimensions property to break the ambiguity. 

Note that this leaves two places with exceptions (vector-shaped biases, and constant diffusions). This makes me sad. It makes sense to, some time soon, consider a type of annotated meta-data system (this is essentially a type of named tensor dimension) that properly annotates event dimensions. But, this PR should at least make the built-in types work correctly.