### PR TITLE
Matt's docstrings and edits for no-numpyro

### DIFF
--- a/docs/api_reference/public/simulators/simulator_configs.md
+++ b/docs/api_reference/public/simulators/simulator_configs.md
@@ -1,0 +1,28 @@
+# Simulator Configurations
+
+Simulator configurations control how continuous-time trajectories are solved.
+Use `ODESimulatorConfig` for deterministic continuous-time dynamics and
+`SDESimulatorConfig` for stochastic continuous-time dynamics. Discrete-time
+simulation samples the transition distribution directly and does not accept a
+simulator configuration.
+
+## `SimulatorConfig`
+
+::: dynestyx.inference.configs.simulator.SimulatorConfig
+    options:
+      show_root_heading: false
+      show_root_toc_entry: true
+
+## `ODESimulatorConfig`
+
+::: dynestyx.inference.configs.simulator.ODESimulatorConfig
+    options:
+      show_root_heading: false
+      show_root_toc_entry: true
+
+## `SDESimulatorConfig`
+
+::: dynestyx.inference.configs.simulator.SDESimulatorConfig
+    options:
+      show_root_heading: false
+      show_root_toc_entry: true

--- a/dynestyx/api.py
+++ b/dynestyx/api.py
@@ -28,7 +28,6 @@ def simulate(
     dynamics: DynamicalModel,
     *,
     rng_key,
-    obs_times: Real[Array, "*obs_time_plate obs_time"] | None = None,
     ctrl_times: Real[Array, "*ctrl_time_plate ctrl_time"] | None = None,
     ctrl_values: Real[Array, "*ctrl_value_plate ctrl_time control_dim"]
     | Real[Array, "*ctrl_value_plate ctrl_time"]
@@ -39,21 +38,15 @@ def simulate(
 ) -> SimulatedResult:
     """Simulate states and observations without registering NumPyro sites.
 
-    The simulation uses `predict_times` when provided and otherwise uses
-    `obs_times`. Native SDE models require `predict_times` and do not accept
-    `obs_times`.
+    The simulation runs on the grid specified by `predict_times`.
 
     Args:
         dynamics: Dynamical model to simulate.
         rng_key: JAX pseudorandom number generator key.
-        obs_times: Fallback simulation times for discrete-time and
-            deterministic continuous-time models.
         ctrl_times: Times associated with `ctrl_values`. If controls are
-            provided, these times must match the union of the supplied
-            observation and prediction times.
+            provided, these times must match `predict_times`.
         ctrl_values: Control values, or `None` for an uncontrolled model.
-        predict_times: Preferred simulation times. Native SDE models require
-            this argument.
+        predict_times: Times at which to simulate states and observations.
         n_simulations: Number of independent trajectories to simulate.
         simulator_config: ODE or SDE solver configuration. Its type must match
             the model's state evolution. Discrete-time models do not accept a
@@ -64,24 +57,22 @@ def simulate(
             observations.
 
     Raises:
-        ValueError: If no simulation times are provided, controls are
-            incomplete or incompatible with the model, the simulator
-            configuration does not match the model, or a native SDE receives
-            `obs_times`.
+        ValueError: If `predict_times` is not provided, controls are incomplete
+            or incompatible with the model, or the simulator configuration does
+            not match the model.
         equinox.EquinoxRuntimeError: If a time array is not strictly
             increasing, `ctrl_times` does not match the required time grid, or
-            `dynamics.t0` does not match the earliest supplied time.
+            `dynamics.t0` does not match the first prediction time.
     """
-    if obs_times is None and predict_times is None:
-        raise ValueError("At least one of obs_times or predict_times must be provided")
+    if predict_times is None:
+        raise ValueError("predict_times must be provided")
 
-    _validate_site_sorting(obs_times, name="obs_times")
     _validate_site_sorting(ctrl_times, name="ctrl_times")
     _validate_site_sorting(predict_times, name="predict_times")
-    _validate_controls(obs_times, predict_times, ctrl_times, ctrl_values)
+    _validate_controls(None, predict_times, ctrl_times, ctrl_values)
     _validate_control_dim(dynamics, ctrl_values)
 
-    dynamics_with_t0 = _get_dynamics_with_t0(dynamics, obs_times, predict_times)
+    dynamics_with_t0 = _get_dynamics_with_t0(dynamics, None, predict_times)
 
     from dynestyx.simulation import Simulator
 
@@ -93,7 +84,6 @@ def simulate(
     return simulator.simulate(
         dynamics_with_t0,
         rng_key=simulation_key,
-        obs_times=obs_times,
         ctrl_times=ctrl_times,
         ctrl_values=ctrl_values,
         predict_times=predict_times,

--- a/dynestyx/simulation/auto.py
+++ b/dynestyx/simulation/auto.py
@@ -82,7 +82,6 @@ class Simulator(BaseSimulator):
         dynamics: DynamicalModel,
         *,
         rng_key: Array,
-        obs_times=None,
         ctrl_times=None,
         ctrl_values=None,
         predict_times=None,
@@ -99,7 +98,6 @@ class Simulator(BaseSimulator):
         return simulator.simulate(
             dynamics,
             rng_key=rng_key,
-            obs_times=obs_times,
             ctrl_times=ctrl_times,
             ctrl_values=ctrl_values,
             predict_times=predict_times,

--- a/dynestyx/simulation/auto.py
+++ b/dynestyx/simulation/auto.py
@@ -20,14 +20,172 @@ from dynestyx.types import SimulatedResult
 
 
 class Simulator(BaseSimulator):
-    """Auto-selecting simulator wrapper.
+    r"""Generate trajectories using the simulator appropriate for the model.
 
-    Chooses a concrete simulator based on the structure of
-    ``dynamics.state_evolution``:
+    `Simulator` is the auto-routing simulator handler. Given prediction times
+    \(t_{0:T-1}\), it draws `n_simulations` independent trajectories from the
+    dynamical model:
 
-    - stochastic continuous-time -> ``SDESimulator``
-    - deterministic continuous-time -> ``ODESimulator``
-    - otherwise -> ``DiscreteTimeSimulator``
+    \[
+    x_0^{(m)} \sim p_0(x_0), \qquad
+    x_{1:T-1}^{(m)}
+      \sim p(x_{1:T-1}\mid x_0^{(m)},u_{1:T-1},t_{1:T-1}),
+    \qquad
+    y_k^{(m)} \sim p(y_k\mid x_k^{(m)}, u_k, t_k).
+    \]
+
+    For continuous-time models, the middle term denotes a numerical ODE or SDE
+    solve evaluated at `predict_times`. For discrete-time models, it denotes
+    successive draws from the transition distribution between adjacent
+    prediction times.
+
+    Use `Simulator` as a context manager around model execution when the model
+    contains `dsx.sample(name, dynamics, predict_times=...)`. The active NumPyro
+    seed supplies randomness; the rollout itself is computed with pure JAX and
+    its realized arrays are then attached to the NumPyro trace. For
+    continuous-time models, pass an
+    [ODESimulatorConfig][dynestyx.inference.configs.simulator.ODESimulatorConfig]
+    or
+    [SDESimulatorConfig][dynestyx.inference.configs.simulator.SDESimulatorConfig]
+    as `simulator_config` to control how the differential equation is solved.
+    Use [dsx.simulate][dynestyx.api.simulate] instead when no NumPyro trace is
+    needed and an explicit `rng_key` is more convenient.
+
+    Examples:
+        Prior-predictive trajectories with automatic backend selection:
+
+        >>> def model(predict_times=None):
+        ...     dynamics = DynamicalModel(...)
+        ...     dsx.sample("f", dynamics, predict_times=predict_times)
+        >>> with Simulator(n_simulations=4):
+        ...     predictive = Predictive(
+        ...         model, num_samples=20, exclude_deterministic=False
+        ...     )
+        ...     draws = predictive(jr.PRNGKey(0), predict_times=times)
+        >>> draws["f_states"].shape
+        (20, 4, T, state_dim)
+
+        Pure-JAX forward simulation returns the same trajectory fields without
+        adding NumPyro sites:
+
+        >>> result = dsx.simulate(
+        ...     dynamics,
+        ...     rng_key=jr.PRNGKey(0),
+        ...     predict_times=times,
+        ...     n_simulations=4,
+        ... )
+
+        For posterior state rollouts, place the simulator outside the inference
+        handler and retain deterministic sites from `Predictive`:
+
+        >>> with Simulator(n_simulations=100):
+        ...     with Filter():
+        ...         predictive = Predictive(
+        ...             model,
+        ...             posterior_samples=posterior_samples,
+        ...             exclude_deterministic=False,
+        ...         )
+        ...         forecast = predictive(
+        ...             jr.PRNGKey(1),
+        ...             obs_times=obs_times,
+        ...             obs_values=obs_values,
+        ...             predict_times=forecast_times,
+        ...         )
+
+    What this does
+    --------------
+    The concrete backend is selected from `dynamics.state_evolution`:
+
+    - `StochasticContinuousTimeStateEvolution` uses
+      [SDESimulator][dynestyx.simulation.sde.SDESimulator].
+    - `DeterministicContinuousTimeStateEvolution` uses
+      [ODESimulator][dynestyx.simulation.ode.ODESimulator].
+    - Discrete-time state evolution uses
+      [DiscreteTimeSimulator][dynestyx.simulation.discrete.DiscreteTimeSimulator].
+
+    A simulator is generation-only: raw simulator calls accept
+    `predict_times`, not `obs_times` or `obs_values`. For observation-conditioned
+    inference, use
+    [LatentPathBuilder][dynestyx.inference.latent.builder.LatentPathBuilder],
+    [Filter][dynestyx.inference.filters.Filter], or
+    [Smoother][dynestyx.inference.smoothers.Smoother]. A simulator may wrap a
+    `Filter` or `Smoother` to draw posterior rollouts at `predict_times`; in
+    that composition, the inference handler consumes the observations and
+    passes posterior state distributions outward to the simulator.
+
+    Configurations and defaults
+    ---------------------------
+    `simulator_config` accepts a
+    [SimulatorConfig][dynestyx.inference.configs.simulator.SimulatorConfig] and
+    forwards it to the selected continuous-time backend:
+
+    - stochastic continuous-time models accept `SDESimulatorConfig`;
+    - deterministic continuous-time models accept `ODESimulatorConfig`;
+    - discrete-time models do not accept a simulator config.
+
+    If `simulator_config=None`, discrete transitions are sampled directly,
+    deterministic continuous-time models use the `ODESimulatorConfig` defaults
+    (`diffrax.Tsit5()` with fixed `dt0=1e-3`), and stochastic continuous-time
+    models use the `SDESimulatorConfig` defaults (the fixed-step `"em_scan"`
+    Euler--Maruyama backend with `dt0=1e-4`). `n_simulations` defaults to one
+    and must be at least one. The simulation dimension is retained even when it
+    has length one.
+
+    NumPyro trace
+    -------------
+    For a raw rollout from `dsx.sample("f", ...)`, the following
+    `numpyro.deterministic` sites are added:
+
+    - `"f_x_0"`: initial states, shape
+      `(*plate_shape, n_simulations, state_dim)`;
+    - `"f_times"`: prediction times, shape
+      `(*plate_shape, n_simulations, T)`;
+    - `"f_states"`: latent states, shape
+      `(*plate_shape, n_simulations, T, state_dim)`;
+    - `"f_observations"`: sampled observations, shape
+      `(*plate_shape, n_simulations, T, observation_dim)`.
+
+    Here `"f"` is replaced by the `name` passed to `dsx.sample`, `T` is the
+    length of the prediction grid, and `plate_shape` is absent outside a
+    `dsx.plate`. Under `Predictive(..., num_samples=N)`, NumPyro prepends an
+    `N` axis to every shape above. Because these sites are deterministic, pass
+    `exclude_deterministic=False` to `Predictive` (or request the site names
+    explicitly) to include them in its returned dictionary.
+
+    When the simulator wraps a `Filter` or `Smoother`, the inner handler records
+    its own configured sites and the simulator's aggregate rollout sites are
+    instead `"f_predicted_times"`, `"f_predicted_states"`, and
+    `"f_predicted_observations"`, with the corresponding time, state, and
+    observation shapes above. Each nonempty prediction segment also records
+    the state from which that segment starts, with shape
+    `(n_simulations, state_dim)`: `"f_0_x_0"` for a segment before the first
+    posterior time, and `"f_{j+1}_x_0"` for a segment initialized from the
+    posterior at inference-time index `j`. Only segments containing at least
+    one requested prediction time are recorded. Inside `dsx.plate`, the segment
+    name also identifies the plate member, for example `"f_p0_1_x_0"`.
+
+    If `predict_times` is omitted, the simulator performs no rollout and adds
+    no simulator sites. Direct calls to
+    [Simulator().simulate][dynestyx.simulation.auto.Simulator.simulate] and
+    [dsx.simulate][dynestyx.api.simulate] return a `SimulatedResult` and do not
+    add NumPyro sites.
+
+    Notes:
+        - Controls are passed through to the selected backend. See the concrete
+          simulator for its control interpolation or alignment rules.
+        - A `Simulator` instance selects and caches its concrete backend on the
+          first dynamics object it handles. Use separate instances for models
+          requiring different backend types.
+        - `Simulator().simulate(...)` consumes an already allocated simulation
+          key. The public [dsx.simulate][dynestyx.api.simulate] function splits
+          its root key before dispatch.
+
+    Attributes:
+        simulator_config: Optional ODE or SDE solver configuration. Its type
+            must match the model selected at first use.
+        n_simulations: Number of independent trajectories drawn per model
+            execution. Defaults to one and must be greater than or equal to one.
+        simulator: Concrete auto-selected simulator cached on first use.
     """
 
     def __init__(
@@ -89,10 +247,10 @@ class Simulator(BaseSimulator):
     ) -> SimulatedResult:
         """Auto-route to the appropriate pure-JAX simulator backend.
 
-        Unlike :func:`dynestyx.simulate`, ``rng_key`` is consumed directly as an
-        already-allocated simulation key and is not pre-split. Therefore,
-        ``dynestyx.simulate(..., rng_key=root_key)`` is equivalent to
-        ``Simulator.simulate(..., rng_key=jax.random.split(root_key)[1])``.
+        Unlike [dsx.simulate][dynestyx.api.simulate], `rng_key` is consumed
+        directly as an already-allocated simulation key and is not pre-split.
+        Therefore, `dsx.simulate(..., rng_key=root_key)` is equivalent to
+        `Simulator().simulate(..., rng_key=jax.random.split(root_key)[1])`.
         """
         simulator = self._ensure_simulator(dynamics)
         return simulator.simulate(

--- a/dynestyx/simulation/base.py
+++ b/dynestyx/simulation/base.py
@@ -77,11 +77,6 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
         dynamics: DynamicalModel,
         *,
         rng_key: Array | None = None,
-        obs_times=None,
-        obs_values=None,
-        _obs_values_filled=None,
-        _obs_mask=None,
-        _obs_has_missing=None,
         ctrl_times=None,
         ctrl_values=None,
         predict_times=None,
@@ -115,11 +110,8 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
                 "Plate-aware rollout requires posterior distributions from Filter/Smoother."
             )
 
-        # Need times to simulate: predict_times or obs_times
-        # For posterior rollout, need predict_times
         if predict_times is None:
-            if obs_times is None or rollout_times is not None:
-                return None
+            return None
 
         posterior_rollout = rollout_times is not None and rollout_dists is not None
 
@@ -257,23 +249,11 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
                 ),
             )
 
-        if self.n_simulations > 1 and obs_values is not None:
-            raise ValueError(
-                "n_simulations > 1 is only supported when obs_values is None "
-                "(forward simulation only)"
-            )
         if rng_key is None:
             raise ValueError("PRNG key required for simulation.")
-        if obs_times is not None or obs_values is not None:
-            raise ValueError(
-                f"{type(self).__name__} is generation-only. Use predict_times for "
-                "simulation, or LatentPathBuilder / Filter / Smoother for inference "
-                "with observations."
-            )
         return self.simulate(
             dynamics,
             rng_key=rng_key,
-            obs_times=obs_times,
             ctrl_times=ctrl_times,
             ctrl_values=ctrl_values,
             predict_times=predict_times,
@@ -287,11 +267,6 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
         *,
         rng_key: Array | None = None,
         plate_shapes: tuple[int, ...],
-        obs_times=None,
-        obs_values=None,
-        _obs_values_filled=None,
-        _obs_mask=None,
-        _obs_has_missing=None,
         ctrl_times=None,
         ctrl_values=None,
         predict_times=None,
@@ -307,12 +282,13 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
         Plated simulation enumerates over all plate members and runs
         individual simulations. This is somewhat slower than vmapping,
         but maintains full compatibility with NumPyro's sample semantics."""
+        if predict_times is None:
+            return None
+
         if not _has_any_batched_plate_source(
             dynamics,
             plate_shapes,
             arrays=(
-                obs_times,
-                obs_values,
                 ctrl_times,
                 ctrl_values,
                 predict_times,
@@ -339,18 +315,6 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
             )
 
             # We then slice each other source to find the member's times/values.
-            member_obs_times = _slice_array_for_plate_member(
-                obs_times, plate_shapes, plate_idx
-            )
-            member_obs_values = _slice_array_for_plate_member(
-                obs_values, plate_shapes, plate_idx
-            )
-            member_obs_values_filled = _slice_array_for_plate_member(
-                _obs_values_filled, plate_shapes, plate_idx
-            )
-            member_obs_mask = _slice_array_for_plate_member(
-                _obs_mask, plate_shapes, plate_idx
-            )
             member_ctrl_times = _slice_array_for_plate_member(
                 ctrl_times, plate_shapes, plate_idx
             )
@@ -385,11 +349,6 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
                 member_name,
                 member_dynamics,
                 rng_key=(None if member_keys is None else member_keys[member_idx]),
-                obs_times=member_obs_times,
-                obs_values=member_obs_values,
-                _obs_values_filled=member_obs_values_filled,
-                _obs_mask=member_obs_mask,
-                _obs_has_missing=_obs_has_missing,
                 ctrl_times=member_ctrl_times,
                 ctrl_values=member_ctrl_values,
                 predict_times=member_predict_times,
@@ -437,13 +396,7 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
         posterior_rollout_final_only = kwargs.pop(
             "_posterior_rollout_final_only", False
         )
-        raw_simulator_request = (
-            filtered_times is None
-            and filtered_dists is None
-            and smoothed_times is None
-            and smoothed_dists is None
-        )
-        if raw_simulator_request and (obs_times is not None or obs_values is not None):
+        if obs_times is not None or obs_values is not None:
             raise ValueError(
                 "Simulator handlers are generation-only and no longer accept "
                 "obs_times/obs_values directly. Use predict_times for forward "
@@ -462,11 +415,6 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
                 dynamics,
                 rng_key=simulation_key,
                 plate_shapes=plate_shapes,
-                obs_times=obs_times,
-                obs_values=obs_values,
-                _obs_values_filled=_obs_values_filled,
-                _obs_mask=_obs_mask,
-                _obs_has_missing=_obs_has_missing,
                 ctrl_times=ctrl_times,
                 ctrl_values=ctrl_values,
                 predict_times=predict_times,
@@ -482,11 +430,6 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
                 name,
                 dynamics,
                 rng_key=simulation_key,
-                obs_times=obs_times,
-                obs_values=obs_values,
-                _obs_values_filled=_obs_values_filled,
-                _obs_mask=_obs_mask,
-                _obs_has_missing=_obs_has_missing,
                 ctrl_times=ctrl_times,
                 ctrl_values=ctrl_values,
                 predict_times=predict_times,
@@ -502,11 +445,8 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
             name,
             dynamics,
             plate_shapes=plate_shapes,
-            obs_times=obs_times,
-            obs_values=obs_values,
-            _obs_values_filled=_obs_values_filled,
-            _obs_mask=_obs_mask,
-            _obs_has_missing=_obs_has_missing,
+            obs_times=None,
+            obs_values=None,
             ctrl_times=ctrl_times,
             ctrl_values=ctrl_values,
             predict_times=predict_times,
@@ -534,7 +474,6 @@ class BaseSimulator(ObjectInterpretation, HandlesSelf):
         dynamics: DynamicalModel,
         *,
         rng_key: Array,
-        obs_times=None,
         ctrl_times=None,
         ctrl_values=None,
         predict_times=None,

--- a/dynestyx/simulation/discrete.py
+++ b/dynestyx/simulation/discrete.py
@@ -101,7 +101,135 @@ def _sample_discrete_state_path(
 
 
 class DiscreteTimeSimulator(BaseSimulator):
-    """Forward simulator for discrete-time dynamical models."""
+    r"""Generate trajectories from a discrete-time dynamical model.
+
+    For prediction times \(t_0,\ldots,t_{T-1}\), this simulator draws
+    `n_simulations` independent paths according to
+
+    \[
+    x_0^{(m)} \sim p_0(x_0), \qquad
+    x_{k+1}^{(m)}
+      \sim p\!\left(x_{k+1}\mid x_k^{(m)},u_k,t_k,t_{k+1}\right),
+    \qquad
+    y_k^{(m)} \sim p(y_k\mid x_k^{(m)},u_k,t_k).
+    \]
+
+    The first state in the returned path is the initial-condition draw at
+    `predict_times[0]`; the simulator then makes one transition draw for each
+    adjacent pair of prediction times and samples one observation conditional
+    on every realized state. See
+    [DiscreteTimeStateEvolution][dynestyx.models.core.DiscreteTimeStateEvolution]
+    for how a discrete transition model is represented in a `DynamicalModel`.
+
+    Use `DiscreteTimeSimulator` as a context manager around a model containing
+    `dsx.sample(name, dynamics, predict_times=...)`. The active NumPyro seed
+    supplies randomness, while the realized paths are attached to the trace as
+    deterministic sites. Use [dsx.simulate][dynestyx.api.simulate] for
+    standalone pure-JAX generation without a NumPyro trace.
+
+    Examples:
+        >>> def model(predict_times=None):
+        ...     dynamics = DynamicalModel(
+        ...         initial_condition=initial_dist,
+        ...         state_evolution=transition,
+        ...         observation_model=observation,
+        ...     )
+        ...     dsx.sample("f", dynamics, predict_times=predict_times)
+        >>> with DiscreteTimeSimulator(n_simulations=3):
+        ...     predictive = Predictive(
+        ...         model, num_samples=10, exclude_deterministic=False
+        ...     )
+        ...     draws = predictive(
+        ...         jr.PRNGKey(0), predict_times=jnp.arange(20.0)
+        ...     )
+        >>> draws["f_states"].shape
+        (10, 3, 20, state_dim)
+
+        For one direct, pure-JAX model execution:
+
+        >>> result = dsx.simulate(
+        ...     dynamics,
+        ...     rng_key=jr.PRNGKey(0),
+        ...     predict_times=jnp.arange(20.0),
+        ...     n_simulations=3,
+        ... )
+
+    What this does
+    --------------
+    The transition distribution is evaluated with the current state, current
+    control, and the two adjacent time values. Prediction times therefore need
+    not be uniformly spaced, provided the model's transition accepts those
+    intervals.
+
+    If controls are supplied, `ctrl_times` must contain every prediction time
+    exactly. `ctrl_values[k]` is used for the transition beginning at \(t_k\)
+    and for the observation at \(t_k\). The paired control arrays are validated
+    before simulation.
+
+    This handler is generation-only and does not condition on `obs_times` or
+    `obs_values`. Use
+    [LatentPathBuilder][dynestyx.inference.latent.builder.LatentPathBuilder]
+    for explicit latent-path inference, or use
+    [Filter][dynestyx.inference.filters.Filter] or
+    [Smoother][dynestyx.inference.smoothers.Smoother] for marginalized
+    inference. Placing this simulator outside a compatible `Filter` or
+    `Smoother` draws posterior rollouts at `predict_times`.
+
+    Configuration and defaults
+    --------------------------
+    Discrete simulation has no solver configuration: transitions are sampled
+    directly from `dynamics.state_evolution`. `n_simulations` defaults to one
+    and must be at least one. The simulation dimension is retained even when it
+    has length one.
+
+    NumPyro trace
+    -------------
+    For a raw rollout from `dsx.sample("f", ...)`, the following
+    `numpyro.deterministic` sites are added:
+
+    - `"f_x_0"`: initial states, shape
+      `(*plate_shape, n_simulations, state_dim)`;
+    - `"f_times"`: prediction times, shape
+      `(*plate_shape, n_simulations, T)`;
+    - `"f_states"`: latent states, shape
+      `(*plate_shape, n_simulations, T, state_dim)`;
+    - `"f_observations"`: sampled observations, shape
+      `(*plate_shape, n_simulations, T, observation_dim)`.
+
+    Here `"f"` is replaced by the `name` passed to `dsx.sample`. Under
+    `Predictive(..., num_samples=N)`, NumPyro prepends an `N` axis to each
+    shape. Because these sites are deterministic, pass
+    `exclude_deterministic=False` to `Predictive` (or request the site names
+    explicitly) to include them in its returned dictionary.
+
+    When this simulator wraps a `Filter` or `Smoother`, the inner handler
+    records its own configured sites and the simulator's aggregate rollout
+    sites are instead `"f_predicted_times"`, `"f_predicted_states"`, and
+    `"f_predicted_observations"`, with the corresponding time, state, and
+    observation shapes above. Each nonempty prediction segment also records
+    the state from which that segment starts, with shape
+    `(n_simulations, state_dim)`: `"f_0_x_0"` for a segment before the first
+    posterior time, and `"f_{j+1}_x_0"` for a segment initialized from the
+    posterior at inference-time index `j`. Only segments containing at least
+    one requested prediction time are recorded. Inside `dsx.plate`, the segment
+    name also identifies the plate member, for example `"f_p0_1_x_0"`.
+
+    If `predict_times` is omitted, no simulator rollout or simulator trace
+    sites are produced. Direct calls to
+    [DiscreteTimeSimulator().simulate][dynestyx.simulation.discrete.DiscreteTimeSimulator.simulate]
+    return `SimulatedResult` without adding NumPyro sites.
+
+    Notes:
+        - Use `Simulator` instead when automatic selection among discrete, ODE,
+          and SDE backends is desirable.
+        - `DiscreteTimeSimulator().simulate(...)` consumes an already allocated
+          simulation key. The public [dsx.simulate][dynestyx.api.simulate]
+          function splits its root key before dispatch.
+
+    Attributes:
+        n_simulations: Number of independent trajectories drawn per model
+            execution. Defaults to one and must be greater than or equal to one.
+    """
 
     def __init__(
         self,
@@ -168,10 +296,11 @@ class DiscreteTimeSimulator(BaseSimulator):
     ) -> SimulatedResult:
         """Run pure-JAX forward simulation for a discrete-time model.
 
-        Unlike :func:`dynestyx.simulate`, ``rng_key`` is consumed directly as an
-        already-allocated simulation key and is not pre-split. Therefore,
-        ``dynestyx.simulate(..., rng_key=root_key)`` is equivalent to
-        ``DiscreteTimeSimulator.simulate(..., rng_key=jax.random.split(root_key)[1])``.
+        Unlike [dsx.simulate][dynestyx.api.simulate], `rng_key` is consumed
+        directly as an already-allocated simulation key and is not pre-split.
+        Therefore, `dsx.simulate(..., rng_key=root_key)` is equivalent to
+        `DiscreteTimeSimulator().simulate(..., rng_key=split_key)`, where
+        `split_key = jax.random.split(root_key)[1]`.
         """
         if predict_times is None:
             raise ValueError("predict_times must be provided")

--- a/dynestyx/simulation/discrete.py
+++ b/dynestyx/simulation/discrete.py
@@ -161,7 +161,6 @@ class DiscreteTimeSimulator(BaseSimulator):
         dynamics: DynamicalModel,
         *,
         rng_key: Array,
-        obs_times=None,
         ctrl_times=None,
         ctrl_values=None,
         predict_times=None,
@@ -174,12 +173,11 @@ class DiscreteTimeSimulator(BaseSimulator):
         ``dynestyx.simulate(..., rng_key=root_key)`` is equivalent to
         ``DiscreteTimeSimulator.simulate(..., rng_key=jax.random.split(root_key)[1])``.
         """
-        times = obs_times if obs_times is not None else predict_times
-        if times is None:
-            raise ValueError("obs_times or predict_times must be provided")
+        if predict_times is None:
+            raise ValueError("predict_times must be provided")
 
         aligned_ctrl_values = _align_ctrl_values_to_times(
-            times=times,
+            times=predict_times,
             ctrl_times=ctrl_times,
             ctrl_values=ctrl_values,
         )
@@ -193,6 +191,6 @@ class DiscreteTimeSimulator(BaseSimulator):
             dynamics,
             initial_state=initial_state,
             rng_key=rollout_key,
-            times=times,
+            times=predict_times,
             ctrl_values=aligned_ctrl_values,
         )

--- a/dynestyx/simulation/ode.py
+++ b/dynestyx/simulation/ode.py
@@ -14,7 +14,154 @@ from dynestyx.utils import _build_control_path_eval
 
 
 class ODESimulator(BaseSimulator):
-    """Forward simulator for continuous-time deterministic dynamics (ODEs)."""
+    r"""Generate trajectories from deterministic continuous-time dynamics.
+
+    For an initial-condition distribution \(p_0\), drift function \(f\), and
+    observation model \(p(y\mid x,u,t)\), `ODESimulator` draws
+    `n_simulations` independent initial states and computes
+
+    \[
+    x_0^{(m)} \sim p_0(x_0), \qquad
+    \frac{\mathrm{d}x^{(m)}(t)}{\mathrm{d}t}
+      = f\!\left(x^{(m)}(t),u(t),t\right), \qquad
+    y_k^{(m)} \sim p\!\left(y_k\mid x^{(m)}(t_k),u(t_k),t_k\right).
+    \]
+
+    The ODE solution is evaluated at every value in `predict_times`. Conditional
+    on the initial state and controls, the state path is deterministic; the
+    initial-condition and observation distributions may still make the complete
+    simulation stochastic. See
+    [ContinuousTimeStateEvolution][dynestyx.models.core.ContinuousTimeStateEvolution]
+    for how an ODE is represented in a `DynamicalModel` by specifying its drift
+    without a diffusion.
+
+    Use `ODESimulator` as a context manager around a model containing
+    `dsx.sample(name, dynamics, predict_times=...)`. The active NumPyro seed
+    supplies randomness, and the computed arrays are then attached to the trace
+    as deterministic sites. Pass an
+    [ODESimulatorConfig][dynestyx.inference.configs.simulator.ODESimulatorConfig]
+    to choose the Diffrax solver, step-size controller, adjoint, step size, and
+    step limit. Use [dsx.simulate][dynestyx.api.simulate] for standalone
+    pure-JAX generation without a NumPyro trace.
+
+    Examples:
+        Prior-predictive ODE trajectories:
+
+        >>> def model(predict_times=None):
+        ...     dynamics = DynamicalModel(
+        ...         initial_condition=initial_dist,
+        ...         state_evolution=ContinuousTimeStateEvolution(
+        ...             drift=lambda x, u, t: -rate * x,
+        ...         ),
+        ...         observation_model=observation,
+        ...     )
+        ...     dsx.sample("f", dynamics, predict_times=predict_times)
+        >>> config = ODESimulatorConfig(dt0=1e-2)
+        >>> with ODESimulator(config, n_simulations=3):
+        ...     predictive = Predictive(
+        ...         model, num_samples=10, exclude_deterministic=False
+        ...     )
+        ...     draws = predictive(
+        ...         jr.PRNGKey(0), predict_times=jnp.linspace(0.0, 5.0, 51)
+        ...     )
+        >>> draws["f_states"].shape
+        (10, 3, 51, state_dim)
+
+        Standalone pure-JAX simulation uses the same ODE solver:
+
+        >>> result = dsx.simulate(
+        ...     dynamics,
+        ...     rng_key=jr.PRNGKey(0),
+        ...     predict_times=times,
+        ...     n_simulations=3,
+        ...     simulator_config=ODESimulatorConfig(dt0=1e-2),
+        ... )
+
+    What this does
+    --------------
+    Each initial-condition draw is integrated independently with Diffrax. The
+    integration starts at `dynamics.t0` when it is defined and otherwise at the
+    first prediction time. The solved state is saved only at `predict_times`,
+    after which the observation model is sampled independently at those states.
+
+    If controls are supplied, they form a right-continuous rectilinear path:
+    the control at a knot `ctrl_times[k]` is `ctrl_values[k]`, and that value is
+    held until the next knot.
+
+    This handler is generation-only and does not condition on `obs_times` or
+    `obs_values`. Use
+    [LatentPathBuilder][dynestyx.inference.latent.builder.LatentPathBuilder]
+    for explicit latent-path inference, or use
+    [Filter][dynestyx.inference.filters.Filter] or
+    [Smoother][dynestyx.inference.smoothers.Smoother] for marginalized
+    inference. Placing this simulator outside a compatible continuous-time
+    `Filter` or `Smoother` draws posterior rollouts at `predict_times`.
+
+    Configuration and defaults
+    --------------------------
+    ODEs are solved using Diffrax, and settings are controlled by
+    [ODESimulatorConfig][dynestyx.inference.configs.simulator.ODESimulatorConfig].
+    Its default settings are `diffrax.Tsit5()`,
+    `diffrax.ConstantStepSize()`, `diffrax.RecursiveCheckpointAdjoint()`,
+    `dt0=1e-3`, and `max_steps=100_000`. Pass different settings when the model
+    requires them. If `simulator_config=None`, a default
+    `ODESimulatorConfig()` is created.
+
+    `n_simulations` defaults to one and must be at least one. The simulation
+    dimension is retained even when it has length one.
+
+    NumPyro trace
+    -------------
+    For a raw rollout from `dsx.sample("f", ...)`, the following
+    `numpyro.deterministic` sites are added:
+
+    - `"f_x_0"`: initial states, shape
+      `(*plate_shape, n_simulations, state_dim)`;
+    - `"f_times"`: prediction times, shape
+      `(*plate_shape, n_simulations, T)`;
+    - `"f_states"`: solved states, shape
+      `(*plate_shape, n_simulations, T, state_dim)`;
+    - `"f_observations"`: sampled observations, shape
+      `(*plate_shape, n_simulations, T, observation_dim)`.
+
+    Here `"f"` is replaced by the `name` passed to `dsx.sample`. Under
+    `Predictive(..., num_samples=N)`, NumPyro prepends an `N` axis to each
+    shape. Because these sites are deterministic, pass
+    `exclude_deterministic=False` to `Predictive` (or request the site names
+    explicitly) to include them in its returned dictionary.
+
+    When this simulator wraps a `Filter` or `Smoother`, the inner handler
+    records its own configured sites and the simulator's aggregate rollout
+    sites are instead `"f_predicted_times"`, `"f_predicted_states"`, and
+    `"f_predicted_observations"`, with the corresponding time, state, and
+    observation shapes above. Each nonempty prediction segment also records
+    the state from which that segment starts, with shape
+    `(n_simulations, state_dim)`: `"f_0_x_0"` for a segment before the first
+    posterior time, and `"f_{j+1}_x_0"` for a segment initialized from the
+    posterior at inference-time index `j`. Only segments containing at least
+    one requested prediction time are recorded. Inside `dsx.plate`, the segment
+    name also identifies the plate member, for example `"f_p0_1_x_0"`.
+
+    If `predict_times` is omitted, no simulator rollout or simulator trace
+    sites are produced. Direct calls to
+    [ODESimulator().simulate][dynestyx.simulation.ode.ODESimulator.simulate]
+    return `SimulatedResult` without adding NumPyro sites.
+
+    Notes:
+        - Use `Simulator` instead when automatic selection among discrete, ODE,
+          and SDE backends is desirable.
+        - `ODESimulator().simulate(...)` consumes an already allocated simulation
+          key. The public [dsx.simulate][dynestyx.api.simulate] function splits
+          its root key before dispatch.
+
+    Attributes:
+        simulator_config: ODE solver and integration settings. Defaults to
+            `ODESimulatorConfig()`.
+        n_simulations: Number of independent initial states and trajectories
+            drawn per model execution. Defaults to one and must be greater than
+            or equal to one.
+        diffeqsolve_settings: Normalized settings passed to Diffrax.
+    """
 
     def __init__(
         self,
@@ -99,10 +246,10 @@ class ODESimulator(BaseSimulator):
     ) -> SimulatedResult:
         """Run pure-JAX forward simulation for deterministic continuous-time models.
 
-        Unlike :func:`dynestyx.simulate`, ``rng_key`` is consumed directly as an
-        already-allocated simulation key and is not pre-split. Therefore,
-        ``dynestyx.simulate(..., rng_key=root_key)`` is equivalent to
-        ``ODESimulator.simulate(..., rng_key=jax.random.split(root_key)[1])``.
+        Unlike [dsx.simulate][dynestyx.api.simulate], `rng_key` is consumed
+        directly as an already-allocated simulation key and is not pre-split.
+        Therefore, `dsx.simulate(..., rng_key=root_key)` is equivalent to
+        `ODESimulator().simulate(..., rng_key=jax.random.split(root_key)[1])`.
         """
         if predict_times is None:
             raise ValueError("predict_times must be provided")

--- a/dynestyx/simulation/ode.py
+++ b/dynestyx/simulation/ode.py
@@ -92,7 +92,6 @@ class ODESimulator(BaseSimulator):
         dynamics: DynamicalModel,
         *,
         rng_key: Array,
-        obs_times=None,
         ctrl_times=None,
         ctrl_values=None,
         predict_times=None,
@@ -105,9 +104,8 @@ class ODESimulator(BaseSimulator):
         ``dynestyx.simulate(..., rng_key=root_key)`` is equivalent to
         ``ODESimulator.simulate(..., rng_key=jax.random.split(root_key)[1])``.
         """
-        times = obs_times if obs_times is not None else predict_times
-        if times is None:
-            raise ValueError("obs_times or predict_times must be provided")
+        if predict_times is None:
+            raise ValueError("predict_times must be provided")
 
         initial_key, rollout_key = jr.split(rng_key)
         initial_state = _sample_initial_states(
@@ -119,7 +117,7 @@ class ODESimulator(BaseSimulator):
             dynamics,
             initial_state=initial_state,
             rng_key=rollout_key,
-            times=times,
+            times=predict_times,
             ctrl_times=ctrl_times,
             ctrl_values=ctrl_values,
         )

--- a/dynestyx/simulation/sde.py
+++ b/dynestyx/simulation/sde.py
@@ -14,31 +14,169 @@ from dynestyx.utils import _build_control_path_eval
 
 
 class SDESimulator(BaseSimulator):
-    """Simulator for continuous-time stochastic dynamics (SDEs).
+    r"""Generate trajectories from stochastic continuous-time dynamics.
 
-    This simulator integrates a `ContinuousTimeStateEvolution` with nonzero diffusion
+    For an initial-condition distribution \(p(x_0)\), drift \(f\), diffusion
+    coefficient \(g\), and observation model \(p(y\mid x,u,t)\),
+    `SDESimulator` draws `n_simulations` independent paths satisfying
 
-    Controls:
-        If `ctrl_times` / `ctrl_values` are provided at the `dsx.sample(...)` site,
-        controls are interpolated with a right-continuous rectilinear rule
-        (`left=False`), i.e., the control at time `t_k` is `ctrl_values[k]`.
+    \[
+    \begin{aligned}
+    x_0^{(m)} &\sim p(x_0), \\
+    dx_t^{(m)}
+      &= f(x_t^{(m)},u_t,t)\,dt
+       + g(x_t^{(m)},u_t,t)\,dW_t^{(m)}, \\
+    y_k^{(m)}
+      &\sim p(y_k\mid x_k^{(m)},u_k,t_k).
+    \end{aligned}
+    \]
 
-    Deterministic outputs:
-        When run through `dsx.sample(...)`, the simulator records `"x_0"`,
-        `"times"`, `"states"`, and `"observations"` as
-        `numpyro.deterministic(...)` sites.
+    The numerical SDE solution is evaluated at every value in
+    `predict_times`. Initial states, Brownian paths, and observations are drawn
+    independently across the simulation dimension. See
+    [ContinuousTimeStateEvolution][dynestyx.models.core.ContinuousTimeStateEvolution]
+    for how an SDE is represented in a `DynamicalModel`.
 
-    Important:
-        - Conditioning on `obs_values` with an SDE unroller typically yields a
-          very high-dimensional latent path and is usually a **poor inference
-          strategy** for parameters. Prefer filtering (`Filter` with
-          `ContinuousTime*Config`) or particle methods instead.
+    Use `SDESimulator` as a context manager around a model containing
+    `dsx.sample(name, dynamics, predict_times=...)`. The active NumPyro seed
+    supplies randomness, and the realized paths are then attached to the trace
+    as deterministic sites. Pass an
+    [SDESimulatorConfig][dynestyx.inference.configs.simulator.SDESimulatorConfig]
+    to choose the SDE backend, solver, step-size controller, adjoint, step size,
+    and Brownian-tree tolerance. Use
+    [dsx.simulate][dynestyx.api.simulate] for standalone pure-JAX generation
+    without a NumPyro trace.
 
-    Tip for speed:
-        - Use `SDESimulatorConfig(source="em_scan")` if you are happy with a simple Euler-Maruyama forward simulation
-          (10–20x faster than Diffrax's implementation; see
-          [Diffrax Issue #517](https://github.com/patrick-kidger/diffrax/issues/517)).
-        - Use `SDESimulatorConfig(source="diffrax")` if you want greater flexibility in the solver and step-size control.
+    Examples:
+        Fast fixed-step Euler--Maruyama simulation:
+
+        >>> def model(predict_times=None):
+        ...     dynamics = DynamicalModel(
+        ...         initial_condition=initial_dist,
+        ...         state_evolution=ContinuousTimeStateEvolution(
+        ...             drift=drift,
+        ...             diffusion=diffusion,
+        ...         ),
+        ...         observation_model=observation,
+        ...     )
+        ...     dsx.sample("f", dynamics, predict_times=predict_times)
+        >>> config = SDESimulatorConfig(source="em_scan", dt0=1e-3)
+        >>> with SDESimulator(config, n_simulations=4):
+        ...     predictive = Predictive(
+        ...         model, num_samples=10, exclude_deterministic=False
+        ...     )
+        ...     draws = predictive(
+        ...         jr.PRNGKey(0), predict_times=jnp.linspace(0.0, 5.0, 51)
+        ...     )
+        >>> draws["f_states"].shape
+        (10, 4, 51, state_dim)
+
+        Use the Diffrax backend when a different SDE solver or step-size
+        controller is required:
+
+        >>> config = SDESimulatorConfig(
+        ...     source="diffrax",
+        ...     solver=diffrax.EulerHeun(),
+        ...     dt0=1e-3,
+        ... )
+
+    What this does
+    --------------
+    Each initial-condition draw is integrated with an independent Brownian
+    path. Integration starts at `dynamics.t0` when it is defined and otherwise
+    at the first prediction time. After the state paths are solved, the
+    observation model is sampled independently at the requested times.
+
+    If controls are supplied, they form a right-continuous rectilinear path:
+    the control at a knot `ctrl_times[k]` is `ctrl_values[k]`, and that value is
+    held until the next knot.
+
+    This handler is generation-only and does not condition on `obs_times` or
+    `obs_values`. Native SDE latent-path inference should go through a
+    [Discretizer][dynestyx.discretizers.Discretizer] and
+    [LatentPathBuilder][dynestyx.inference.latent.builder.LatentPathBuilder];
+    use
+    [Filter][dynestyx.inference.filters.Filter] or
+    [Smoother][dynestyx.inference.smoothers.Smoother] for marginalized
+    inference. Placing this simulator outside a compatible continuous-time
+    `Filter` or `Smoother` draws posterior rollouts at `predict_times`.
+
+    Configurations and defaults
+    ---------------------------
+    [SDESimulatorConfig][dynestyx.inference.configs.simulator.SDESimulatorConfig]
+    selects one of two backends:
+
+    - `source="em_scan"` uses a fixed-step Euler--Maruyama `jax.lax.scan`.
+      It is the default and uses `dt0=1e-4`.
+    - `source="diffrax"` uses the configured Diffrax solver, step-size
+      controller, adjoint, and virtual Brownian tree. Defaults include
+      `diffrax.Heun()`, `diffrax.ConstantStepSize()`,
+      `diffrax.RecursiveCheckpointAdjoint()`, and `dt0=1e-4`.
+      `tol_vbt=None` resolves to `dt0 / 2`.
+
+    Solver choice determines the stochastic integral represented by the
+    numerical solution. In particular, the default Diffrax Heun solver
+    converges to a Stratonovich solution, while Euler--Maruyama converges to an
+    Itô solution. This distinction matters for state-dependent diffusion.
+
+    If `simulator_config=None`, a default `SDESimulatorConfig()` is created.
+    `n_simulations` defaults to one and must be at least one. The simulation
+    dimension is retained even when it has length one.
+
+    NumPyro trace
+    -------------
+    For a raw rollout from `dsx.sample("f", ...)`, the following
+    `numpyro.deterministic` sites are added:
+
+    - `"f_x_0"`: initial states, shape
+      `(*plate_shape, n_simulations, state_dim)`;
+    - `"f_times"`: prediction times, shape
+      `(*plate_shape, n_simulations, T)`;
+    - `"f_states"`: solved states, shape
+      `(*plate_shape, n_simulations, T, state_dim)`;
+    - `"f_observations"`: sampled observations, shape
+      `(*plate_shape, n_simulations, T, observation_dim)`.
+
+    Here `"f"` is replaced by the `name` passed to `dsx.sample`. Under
+    `Predictive(..., num_samples=N)`, NumPyro prepends an `N` axis to each
+    shape. Because these sites are deterministic, pass
+    `exclude_deterministic=False` to `Predictive` (or request the site names
+    explicitly) to include them in its returned dictionary.
+
+    When this simulator wraps a `Filter` or `Smoother`, the inner handler
+    records its own configured sites and the simulator's aggregate rollout
+    sites are instead `"f_predicted_times"`, `"f_predicted_states"`, and
+    `"f_predicted_observations"`, with the corresponding time, state, and
+    observation shapes above. Each nonempty prediction segment also records
+    the state from which that segment starts, with shape
+    `(n_simulations, state_dim)`: `"f_0_x_0"` for a segment before the first
+    posterior time, and `"f_{j+1}_x_0"` for a segment initialized from the
+    posterior at inference-time index `j`. Only segments containing at least
+    one requested prediction time are recorded. Inside `dsx.plate`, the segment
+    name also identifies the plate member, for example `"f_p0_1_x_0"`.
+
+    If `predict_times` is omitted, no simulator rollout or simulator trace
+    sites are produced. Direct calls to
+    [SDESimulator().simulate][dynestyx.simulation.sde.SDESimulator.simulate]
+    return `SimulatedResult` without adding NumPyro sites.
+
+    Notes:
+        - Use `Simulator` instead when automatic selection among discrete, ODE,
+          and SDE backends is desirable.
+        - `SDESimulator().simulate(...)` consumes an already allocated simulation
+          key. The public [dsx.simulate][dynestyx.api.simulate] function splits
+          its root key before dispatch.
+
+    Attributes:
+        simulator_config: SDE backend and integration settings. Defaults to
+            `SDESimulatorConfig()`.
+        n_simulations: Number of independent initial states, Brownian paths,
+            and trajectories drawn per model execution. Defaults to one and
+            must be greater than or equal to one.
+        source: Active SDE backend, either `"em_scan"` or `"diffrax"`.
+        diffeqsolve_settings: Normalized Diffrax-style solver settings.
+        tol_vbt: Resolved virtual-Brownian-tree tolerance for the Diffrax
+            backend, or `None` for `"em_scan"`.
     """
 
     def __init__(
@@ -128,10 +266,10 @@ class SDESimulator(BaseSimulator):
     ) -> SimulatedResult:
         """Run pure-JAX forward simulation for stochastic continuous-time models.
 
-        Unlike :func:`dynestyx.simulate`, ``rng_key`` is consumed directly as an
-        already-allocated simulation key and is not pre-split. Therefore,
-        ``dynestyx.simulate(..., rng_key=root_key)`` is equivalent to
-        ``SDESimulator.simulate(..., rng_key=jax.random.split(root_key)[1])``.
+        Unlike [dsx.simulate][dynestyx.api.simulate], `rng_key` is consumed
+        directly as an already-allocated simulation key and is not pre-split.
+        Therefore, `dsx.simulate(..., rng_key=root_key)` is equivalent to
+        `SDESimulator().simulate(..., rng_key=jax.random.split(root_key)[1])`.
         """
         if not isinstance(
             dynamics.state_evolution, StochasticContinuousTimeStateEvolution

--- a/dynestyx/simulation/sde.py
+++ b/dynestyx/simulation/sde.py
@@ -121,7 +121,6 @@ class SDESimulator(BaseSimulator):
         dynamics: DynamicalModel,
         *,
         rng_key: Array,
-        obs_times=None,
         ctrl_times=None,
         ctrl_values=None,
         predict_times=None,
@@ -140,11 +139,6 @@ class SDESimulator(BaseSimulator):
             raise NotImplementedError(
                 "SDESimulator only works with StochasticContinuousTimeStateEvolution, got "
                 f"{type(dynamics.state_evolution)}"
-            )
-        if obs_times is not None:
-            raise ValueError(
-                "obs_times must not be provided to an SDESimulator; use predict_times for "
-                "forward simulation, or use a filter / discretization workflow for inference."
             )
 
         times = predict_times

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
           - DiscreteTimeSimulator: api_reference/public/simulators/discrete_time_simulator.md
           - ODESimulator: api_reference/public/simulators/ode_simulator.md
           - SDESimulator: api_reference/public/simulators/sde_simulator.md
+          - Simulator Configurations: api_reference/public/simulators/simulator_configs.md
       - Diagnostics:
         - Plotting Utilities: api_reference/public/diagnostics/plotting_utils.md
     - Developer API:

--- a/tests/test_simulate_standalone.py
+++ b/tests/test_simulate_standalone.py
@@ -222,19 +222,8 @@ def test_simulate_sde_accepts_structured_config():
 
 
 def test_simulate_rejects_missing_time_grid():
-    with pytest.raises(
-        ValueError, match="At least one of obs_times or predict_times must be provided"
-    ):
+    with pytest.raises(ValueError, match="predict_times must be provided"):
         dsx.simulate(_make_discrete_dynamics(), rng_key=jr.PRNGKey(0))
-
-
-def test_simulate_sde_rejects_obs_times():
-    with pytest.raises(ValueError, match="obs_times must not be provided"):
-        dsx.simulate(
-            _make_sde_dynamics(),
-            rng_key=jr.PRNGKey(0),
-            obs_times=jnp.linspace(0.0, 0.5, 5),
-        )
 
 
 def test_simulate_allows_dirac_ode_models():


### PR DESCRIPTION
This PR:

1. removes `obs_times` stuff from the Simulator interface (`_sample_ds` in BaseSimulator still admits these arguments and gives a helpful error about this being deprecated).

2. Adds a long-form docstring to each of the Simulators (I followed the style of `Filter`'s docstring, which I thought was nice).
- I used AI with this, but was pretty prescriptive and suggested a lot of edits and read in detail.
- I'm quite happy with these docstrings
- At worst, they are too long (but honestly convey lots of useful information, albeit occasionally redundant across the docs, but I think this redundancy is in fact helpful...this is a simple one-stop-shop place to understand what you are doing when you run a Simulator() )
- I admittedly didn't quite check the correctness of the indexing of `"f_{j+1}_x_0"`, but I think it is right.