### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dynestyx"
-version = "0.1.0"
+version = "0.1.1"
 description = "NumPyro integration for dynamical systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
NumPyro-separation PR should be 0.2.0, since it's (very) breaking. Let's cut a 0.1.1 release, which is mostly documentation changes but also HMM missingness support, since the NumPyro-free version is nearing completion.