### PR TITLE
Remove caching

### DIFF
--- a/dynestyx/inference/latent/builder.py
+++ b/dynestyx/inference/latent/builder.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import dataclasses
 import itertools
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 from effectful.ops.semantics import fwd
 from effectful.ops.syntax import ObjectInterpretation, implements
-from jax.core import Tracer
+from jax.errors import TracerArrayConversionError
 from jaxtyping import Array, Bool, Int, PRNGKeyArray, Real
 
 from dynestyx.handlers import HandlesSelf, _condition_intp
@@ -48,6 +50,7 @@ from dynestyx.models import (
 from dynestyx.observation_missingness import (
     MissingObservationMetadata,
     MissingObservationStrategy,
+    _observation_mask_from_values,
     assemble_completed_observations,
     prepare_missing_observation_metadata,
     resolve_missing_observation_strategy,
@@ -57,11 +60,6 @@ from dynestyx.simulation.discrete import _sample_discrete_state_path
 from dynestyx.simulation.utils import _sample_observation_path
 from dynestyx.types import LatentStateResult
 from dynestyx.utils import _build_control_path_eval
-
-_MISSING_OBSERVATION_METADATA_CACHE: dict[
-    tuple[str, str, tuple[int, ...], MissingObservationStrategy],
-    MissingObservationMetadata,
-] = {}
 
 
 def _resolve_missing_observation_metadata(
@@ -73,52 +71,104 @@ def _resolve_missing_observation_metadata(
     obs_values: Real[Array, "obs_time observation_dim"] | Real[Array, " obs_time"],
     obs_mask: Bool[Array, "obs_time observation_dim"] | Bool[Array, " obs_time"],
     strategy: MissingObservationStrategy,
-) -> MissingObservationMetadata:
-    """Return missing-observation metadata for concrete or traced inputs.
+    prepared_metadata: MissingObservationMetadata | None,
+) -> tuple[MissingObservationMetadata, bool]:
+    """Prepare static missing-observation metadata while tracing the model.
 
-    Concrete inputs create and cache the metadata. Traced inputs reuse a
-    compatible cached value.
+    Missingness determines NumPyro site shapes, so its pattern must be known
+    when JAX traces the model. ``ensure_compile_time_eval`` handles observations
+    that are closed-over constants. When compiled inference instead carries
+    observations as dynamic arguments, the active handler reuses metadata from
+    NumPyro's earlier concrete initialization and verifies the runtime mask.
 
     Args:
-        name: Name of the `dsx.sample(...)` site.
-        role: Purpose of the latent values. This value separates cache entries
-            that belong to the same sample site.
+        name: Name of the `dsx.sample(...)` site, used in error messages.
+        role: Purpose of the latent values, used in error messages.
         dynamics: Dynamical model associated with the observations.
         obs_times: Observation times.
-        obs_values: Observation values. Their shape identifies the cache entry.
-        obs_mask: Boolean array that marks observed entries.
-        strategy: Requested missing-observation strategy.
+        obs_values: Observation values whose static missingness is inspected.
+        obs_mask: Runtime boolean observation mask. The static mask is rebuilt
+            from ``obs_values`` so it can be evaluated at compile time.
+        strategy: Requested missing-observation strategy, used in error messages.
+        prepared_metadata: Metadata prepared by an earlier concrete execution
+            of the same handler and sample site.
 
     Returns:
-        MissingObservationMetadata: Prepared metadata for the observation mask.
+        tuple[MissingObservationMetadata, bool]: Metadata for the observation
+            mask and whether it was freshly prepared from static values.
 
     Raises:
-        ValueError: If traced inputs have no compatible cached metadata, or if
-            the cached observation shape does not match `obs_values`.
+        ValueError: If the missingness pattern is genuinely dynamic rather than
+            fixed while JAX prepares the model.
     """
-    cache_key = (name, role, tuple(obs_values.shape), strategy)
-    if any(isinstance(value, Tracer) for value in (obs_times, obs_values, obs_mask)):
-        metadata = _MISSING_OBSERVATION_METADATA_CACHE.get(cache_key)
-        if metadata is None:
-            raise ValueError(
-                "LatentPathBuilder encountered traced observation missingness before "
-                "a compatible concrete model execution. Run the model once with "
-                "concrete obs_times/obs_values before traced replay."
-            )
-        if metadata.observation_shape != tuple(obs_values.shape):
-            raise ValueError(
-                "Cached LatentPathBuilder missingness metadata does not match the "
-                "current observation shape."
-            )
-        return metadata
 
-    metadata = prepare_missing_observation_metadata(
-        dynamics,
-        obs_times=obs_times,
-        obs_mask=obs_mask,
-    )
-    _MISSING_OBSERVATION_METADATA_CACHE[cache_key] = metadata
-    return metadata
+    def _use_prepared_or_raise(
+        exc: Exception,
+    ) -> tuple[MissingObservationMetadata, bool]:
+        if prepared_metadata is not None:
+            if prepared_metadata.observation_shape != tuple(obs_values.shape):
+                raise ValueError(
+                    "Prepared LatentPathBuilder missingness metadata does not "
+                    "match the current observation shape."
+                ) from exc
+
+            expected_obs_mask = (
+                jnp.ones(prepared_metadata.observation_shape, dtype=bool)
+                .at[
+                    jnp.unravel_index(
+                        prepared_metadata.missing_flat_indices,
+                        prepared_metadata.observation_shape,
+                    )
+                ]
+                .set(False)
+            )
+            checked_missing_flat_indices = eqx.error_if(
+                prepared_metadata.missing_flat_indices,
+                jnp.any(obs_mask != expected_obs_mask),
+                "The observation missingness pattern changed after "
+                "LatentPathBuilder prepared its static metadata.",
+            )
+
+            if len(prepared_metadata.observation_shape) == 1:
+                missing_time_indices = checked_missing_flat_indices
+            else:
+                observation_dim = prepared_metadata.observation_shape[-1]
+                missing_time_indices = checked_missing_flat_indices // observation_dim
+            return (
+                dataclasses.replace(
+                    prepared_metadata,
+                    missing_flat_indices=checked_missing_flat_indices,
+                    missing_obs_times=jnp.take(
+                        jnp.asarray(obs_times),
+                        missing_time_indices,
+                        axis=0,
+                    ),
+                ),
+                False,
+            )
+        raise ValueError(
+            "LatentPathBuilder requires a fixed observation missingness pattern "
+            f"while preparing {name!r} ({role}, strategy={strategy!r}). Keep the "
+            "locations of missing values static during a compiled inference run."
+        ) from exc
+
+    try:
+        with jax.ensure_compile_time_eval():
+            static_obs_mask = _observation_mask_from_values(obs_values)
+            return (
+                prepare_missing_observation_metadata(
+                    dynamics,
+                    obs_times=obs_times,
+                    obs_mask=static_obs_mask,
+                ),
+                True,
+            )
+    except TracerArrayConversionError as exc:
+        return _use_prepared_or_raise(exc)
+    except ValueError as exc:
+        if isinstance(exc.__cause__, TracerArrayConversionError):
+            return _use_prepared_or_raise(exc)
+        raise
 
 
 def _sample_missing_observation_prior(
@@ -261,6 +311,13 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
         self.ode_simulator_config = ode_simulator_config
         self.missing_observation_strategy = missing_observation_strategy
         self.chunk_size = chunk_size
+        # NumPyro prepares the model concretely before compiled MCMC replay.
+        # Retain that static layout only on this handler instance, then verify
+        # every dynamic replay against it. This avoids process-global state.
+        self._prepared_missing_observation_metadata: dict[
+            tuple[str, str, tuple[int, ...], MissingObservationStrategy],
+            MissingObservationMetadata,
+        ] = {}
 
     def _sample_single(
         self,
@@ -342,15 +399,27 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
                 "dsx.sample(...)."
             )
 
-        metadata = _resolve_missing_observation_metadata(
+        metadata_role = "observations"
+        metadata_key = (
+            name,
+            metadata_role,
+            tuple(obs_values.shape),
+            self.missing_observation_strategy,
+        )
+        metadata, metadata_was_prepared = _resolve_missing_observation_metadata(
             name=name,
-            role="observations",
+            role=metadata_role,
             dynamics=dynamics,
             obs_times=obs_times,
             obs_values=obs_values,
             obs_mask=obs_mask,
             strategy=self.missing_observation_strategy,
+            prepared_metadata=self._prepared_missing_observation_metadata.get(
+                metadata_key
+            ),
         )
+        if metadata_was_prepared:
+            self._prepared_missing_observation_metadata[metadata_key] = metadata
         exact_observations = isinstance(
             dynamics.observation_model,
             DiracIdentityObservation,

--- a/dynestyx/observation_missingness.py
+++ b/dynestyx/observation_missingness.py
@@ -74,6 +74,16 @@ def _concrete_observation_mask(
     return np.ones(obs_values_np.shape, dtype=bool)
 
 
+def _observation_mask_from_values(
+    obs_values: Array | np.ndarray,
+) -> Bool[Array, " *obs_shape"]:
+    """Return the JAX observation mask used throughout missingness handling."""
+    obs_arr = jnp.asarray(obs_values)
+    if jnp.issubdtype(obs_arr.dtype, jnp.inexact):
+        return ~jnp.isnan(obs_arr)
+    return jnp.ones(obs_arr.shape, dtype=bool)
+
+
 def validate_missing_obs_values(
     missing_obs_values: Real[Array, " n_missing_obs"] | Real[Array, ""],
     *,
@@ -342,10 +352,7 @@ def prepare_observation_views(
 
     obs_arr = jnp.asarray(obs_values)
     concrete_obs_mask = _concrete_observation_mask(obs_values)
-    if jnp.issubdtype(obs_arr.dtype, jnp.inexact):
-        obs_mask = ~jnp.isnan(obs_arr)
-    else:
-        obs_mask = jnp.ones(obs_arr.shape, dtype=bool)
+    obs_mask = _observation_mask_from_values(obs_arr)
     if concrete_obs_mask is not None:
         has_missing = bool(np.any(~concrete_obs_mask))
     else:


### PR DESCRIPTION
## Very AI PR ##

** Goal is to fix an issue where:
`tests/test_latent_path_builder.py::test_latent_path_builder_bare_predictive_draws_dynamical_prior_paths` fails, but running the whole test file in serial passes.


Previously, Dynestyx kept one shared list of “where observations are missing.” That list could accidentally come from another test or dataset with the same shape. This caused tests to pass or fail depending on what ran first.

Here we replace global missingness cache with handler-scoped metadata preparation

Prepare LatentPathBuilder missing-observation metadata automatically during
model tracing. For compiled MCMC replay, retain metadata only on the active
handler instance and validate the runtime mask before reuse.

This removes cross-model cache collisions and test-order dependence while
allowing standalone prior Predictive calls to work without cache warmup.