### PR TITLE
Some Bugfixes for NumPyro-Free Usage

### DIFF
--- a/docs/api_reference/developer/inference/latent_path_builder.md
+++ b/docs/api_reference/developer/inference/latent_path_builder.md
@@ -206,9 +206,18 @@ separate `missing_obs_values` site in this case. Exact missing observations
 support `"auto"` and `"augment"`.
 
 Missingness determines NumPyro site shapes, so its pattern must remain static
-while JAX traces a model. The builder evaluates closed-over observation values
-at compile time and derives missing-observation times from the current time
-array. Do not pass observation values as a dynamic argument to `jax.jit`.
+while JAX traces a model. The builder first attempts to infer the layout from
+concrete observations and caches it by sample site and observation shape. If
+the observations are traced, it uses that cache instead.
+
+For a cold outer-JIT call, pass metadata produced by
+`dsx.prepare_missing_observation_metadata(...)` through
+`dsx.sample(..., missing_obs_metadata=metadata)`. If neither inference nor the
+explicit or cached layout is available, the builder raises an error describing
+both remedies. Missing-observation times are always derived from the current
+`obs_times`; finite values and times may therefore change, while the dynamic
+mask is checked against the retained layout. One explicit metadata object is
+shared across plate members.
 
 ## Implementation modules
 

--- a/docs/api_reference/developer/inference/latent_path_builder.md
+++ b/docs/api_reference/developer/inference/latent_path_builder.md
@@ -205,26 +205,27 @@ to be inferred through `state_path_params`. The builder does not create a
 separate `missing_obs_values` site in this case. Exact missing observations
 support `"auto"` and `"augment"`.
 
-Missingness determines NumPyro site shapes, so its pattern must remain static
-while JAX traces a model. The builder first attempts to infer the layout from
-concrete observations and caches it by sample site and observation shape. If
-the observations are traced, it uses that cache instead.
+The missingness pattern can determine NumPyro site shapes, so it must remain
+static while JAX traces the model. With concrete observations, the builder
+caches the layout by sample site and observation shape.
 
-For a cold outer-JIT call, pass metadata produced by
-`dsx.prepare_missing_observation_metadata(...)` through
-`dsx.sample(..., missing_obs_metadata=metadata)`. If neither inference nor the
-explicit or cached layout is available, the builder raises an error describing
-both remedies. Missing-observation times are always derived from the current
-`obs_times`; finite values and times may therefore change, while the dynamic
-mask is checked against the retained layout. One explicit metadata object is
-shared across plate members.
+There are three supported paths: run concretely, reuse a cache from a concrete
+run, or pass `missing_obs_metadata` directly. The metadata can come from
+`dsx.prepare_missing_observation_metadata(...)` or a manually constructed
+`dsx.MissingObservationMetadata` object.
 
-When plate members have different missingness layouts, create the builder
-outside the model and reuse it so the per-member cache entries survive traced
-MCMC execution. Member-specific sample and deterministic sites retain their
-native shapes. If a ragged field cannot be stacked without changing those
-shapes, its aggregate `LatentStateResult` field is a flat list of per-member
-arrays, ordered with the rightmost plate index varying fastest.
+The recommended pattern defines the model first and applies
+`LatentPathBuilder` when the model runs. Cache reuse requires the same builder
+object for the concrete and traced calls. NumPyro MCMC routines typically make
+the concrete call automatically.
+
+The test suite covers all three paths and ragged MCMC. The builder derives
+missing-observation times from the current `obs_times`, so values and times can
+change while the layout stays fixed.
+
+For plate members with different layouts, use one builder for all traced calls.
+Ragged aggregate fields are flat lists of per-member arrays. Member sites keep
+their shapes, and the rightmost plate index varies fastest.
 
 ## Implementation modules
 

--- a/docs/api_reference/developer/inference/latent_path_builder.md
+++ b/docs/api_reference/developer/inference/latent_path_builder.md
@@ -219,6 +219,13 @@ both remedies. Missing-observation times are always derived from the current
 mask is checked against the retained layout. One explicit metadata object is
 shared across plate members.
 
+When plate members have different missingness layouts, create the builder
+outside the model and reuse it so the per-member cache entries survive traced
+MCMC execution. Member-specific sample and deterministic sites retain their
+native shapes. If a ragged field cannot be stacked without changing those
+shapes, its aggregate `LatentStateResult` field is a flat list of per-member
+arrays, ordered with the rightmost plate index varying fastest.
+
 ## Implementation modules
 
 - `dynestyx.inference.latent.builder` creates the sites, handles plates, records

--- a/docs/api_reference/developer/inference/latent_path_builder.md
+++ b/docs/api_reference/developer/inference/latent_path_builder.md
@@ -205,13 +205,10 @@ to be inferred through `state_path_params`. The builder does not create a
 separate `missing_obs_values` site in this case. Exact missing observations
 support `"auto"` and `"augment"`.
 
-Some JAX transformations trace a model before evaluating it. During tracing,
-the values in the observation mask may not be available to Python. The builder
-therefore creates `MissingObservationMetadata` during a normal model call and
-stores it for later traced calls. It matches the stored data by site name, its
-purpose, the observation shape, and the missing-observation strategy. If no
-match is available, run the model once with ordinary observation arrays before
-applying the JAX transformation.
+Missingness determines NumPyro site shapes, so its pattern must remain static
+while JAX traces a model. The builder evaluates closed-over observation values
+at compile time and derives missing-observation times from the current time
+array. Do not pass observation values as a dynamic argument to `jax.jit`.
 
 ## Implementation modules
 

--- a/docs/api_reference/public/inference/latent_path_builder.md
+++ b/docs/api_reference/public/inference/latent_path_builder.md
@@ -44,6 +44,50 @@ The main output names are intentionally distinct from simulator rollout names:
   from `LatentPathBuilder`
 - `f_states` / `f_times`: rollout outputs from `Simulator` and `dsx.simulate(...)`
 
+## JIT and handler lifetime
+
+The observation missingness layout can determine NumPyro sample-site shapes.
+`LatentPathBuilder` infers and caches the layout whenever observations are
+concrete. An ordinary MCMC or `Predictive` call usually supplies such a call;
+reuse the same builder for later outer-jitted calls.
+
+JAX does not make a concrete call before tracing `jax.jit`. For a cold outer-JIT
+call, prepare the metadata eagerly and close it over in the model:
+
+```python
+metadata = dsx.prepare_missing_observation_metadata(
+    dynamics,
+    obs_times=obs_times,
+    obs_values=obs_values,
+)
+
+def conditioned_model(obs_times=None, obs_values=None, predict_times=None):
+    with dsx.DiscreteTimeSimulator(), dsx.LatentPathBuilder():
+        return dsx.sample(
+            "f",
+            dynamics,
+            obs_times=obs_times,
+            obs_values=obs_values,
+            predict_times=predict_times,
+            missing_obs_metadata=metadata,
+        )
+
+predictive = jax.jit(Predictive(conditioned_model, num_samples=10))
+result = predictive(
+    prediction_key,
+    obs_times=obs_times,
+    obs_values=obs_values,
+    predict_times=predict_times,
+)
+```
+
+Without explicit metadata, construct the builder outside the model so its cache
+persists. If neither metadata nor a cached layout is available, the traced call
+raises an error explaining both options. Observation times and finite values may
+remain dynamic, but their missingness pattern must match the cached or supplied
+layout. One supplied metadata object represents a layout shared by all plate
+members.
+
 ## Implementation Details 
 
 To support arbitrary missingness, and for efficiency, the actual implementation of the `LatentPathBuilder` differs from the simple "unrolling" mental model. In particular, the entire `state_path` is intiialized as a `numpyro` site, via an improper uniform prior. The improper uniform prior is modifying so that calling its `sample` method (for example, as used in `numpyro` MCMC samplers by default) provides draws from the actual SSM prior. In particular:

--- a/docs/api_reference/public/inference/latent_path_builder.md
+++ b/docs/api_reference/public/inference/latent_path_builder.md
@@ -88,6 +88,14 @@ remain dynamic, but their missingness pattern must match the cached or supplied
 layout. One supplied metadata object represents a layout shared by all plate
 members.
 
+For plated observations whose members have different missingness layouts,
+construct one builder outside the model and reuse it during MCMC or other traced
+execution. The builder retains a separate layout for each generated member site.
+Ragged per-member latent metadata cannot be represented by one rectangular result
+array, so the corresponding `LatentStateResult` fields are flat lists of
+per-member arrays. The rightmost plate index varies fastest. Member-specific
+NumPyro sites retain the same native shapes.
+
 ## Implementation Details 
 
 To support arbitrary missingness, and for efficiency, the actual implementation of the `LatentPathBuilder` differs from the simple "unrolling" mental model. In particular, the entire `state_path` is intiialized as a `numpyro` site, via an improper uniform prior. The improper uniform prior is modifying so that calling its `sample` method (for example, as used in `numpyro` MCMC samplers by default) provides draws from the actual SSM prior. In particular:

--- a/docs/api_reference/public/inference/latent_path_builder.md
+++ b/docs/api_reference/public/inference/latent_path_builder.md
@@ -44,57 +44,107 @@ The main output names are intentionally distinct from simulator rollout names:
   from `LatentPathBuilder`
 - `f_states` / `f_times`: rollout outputs from `Simulator` and `dsx.simulate(...)`
 
-## JIT and handler lifetime
+## JIT and the builder cache
 
-The observation missingness layout can determine NumPyro sample-site shapes.
-`LatentPathBuilder` infers and caches the layout whenever observations are
-concrete. An ordinary MCMC or `Predictive` call usually supplies such a call;
-reuse the same builder for later outer-jitted calls.
+The shapes of NumPyro sites constructed by `LatentPathBuilder` depend on the
+missingness pattern. They must therefore be known at compile time.
 
-JAX does not make a concrete call before tracing `jax.jit`. For a cold outer-JIT
-call, prepare the metadata eagerly and close it over in the model:
+There are three paths:
+
+1. Run `LatentPathBuilder` concretely to compute the missingness.
+2. Run it concretely once to fill its cache, and then run it under JIT. NumPyro
+   MCMC routines typically do this automatically.
+3. Provide the missingness metadata directly.
+
+Path 2 must use the same `LatentPathBuilder` object because that object stores
+the cache. The recommended pattern is to define the model first and apply the
+handler when the model runs. Examples of the three paths follow.
+
+### 1. Concrete execution
 
 ```python
-metadata = dsx.prepare_missing_observation_metadata(
-    dynamics,
-    obs_times=obs_times,
-    obs_values=obs_values,
-)
+def conditioned_model(obs_times=None, obs_values=None):
+    return dsx.sample(
+        "f",
+        dynamics,
+        obs_times=obs_times,
+        obs_values=obs_values,
+    )
 
-def conditioned_model(obs_times=None, obs_values=None, predict_times=None):
-    with dsx.DiscreteTimeSimulator(), dsx.LatentPathBuilder():
-        return dsx.sample(
-            "f",
-            dynamics,
-            obs_times=obs_times,
-            obs_values=obs_values,
-            predict_times=predict_times,
-            missing_obs_metadata=metadata,
-        )
+predictive = Predictive(conditioned_model, num_samples=10)
+with dsx.LatentPathBuilder():
+    result = predictive(
+        prediction_key,
+        obs_times=obs_times,
+        obs_values=obs_values,
+    )
+```
 
-predictive = jax.jit(Predictive(conditioned_model, num_samples=10))
-result = predictive(
-    prediction_key,
-    obs_times=obs_times,
-    obs_values=obs_values,
-    predict_times=predict_times,
+### 2. Cached metadata
+
+```python
+builder = dsx.LatentPathBuilder()
+with builder:
+    predictive(
+        warmup_key,
+        obs_times=obs_times,
+        obs_values=obs_values,
+    )
+    result = jax.jit(predictive)(
+        prediction_key,
+        obs_times=obs_times,
+        obs_values=obs_values,
+    )
+```
+
+### 3. Explicit metadata
+
+`dsx.prepare_missing_observation_metadata(...)` can create the metadata from
+concrete data. You can also create it directly:
+
+```python
+obs_times = jnp.array([0.0, 1.0])
+obs_values = jnp.array([[0.0, jnp.nan], [jnp.nan, 1.0]])
+
+metadata = dsx.MissingObservationMetadata(
+    missing_obs_times=jnp.array([0.0, 1.0]),
+    missing_obs_coordinate_indices=jnp.array([1, 0], dtype=jnp.int32),
+    missing_flat_indices=jnp.array([1, 2], dtype=jnp.int32),
+    observation_shape=(2, 2),
+    has_missing=True,
+    has_partial_missing=True,
+    has_fully_missing_rows=False,
 )
 ```
 
-Without explicit metadata, construct the builder outside the model so its cache
-persists. If neither metadata nor a cached layout is available, the traced call
-raises an error explaining both options. Observation times and finite values may
-remain dynamic, but their missingness pattern must match the cached or supplied
-layout. One supplied metadata object represents a layout shared by all plate
-members.
+All fields must match the layout of `obs_values`.
 
-For plated observations whose members have different missingness layouts,
-construct one builder outside the model and reuse it during MCMC or other traced
-execution. The builder retains a separate layout for each generated member site.
-Ragged per-member latent metadata cannot be represented by one rectangular result
-array, so the corresponding `LatentStateResult` fields are flat lists of
-per-member arrays. The rightmost plate index varies fastest. Member-specific
-NumPyro sites retain the same native shapes.
+```python
+def conditioned_model(obs_times=None, obs_values=None):
+    return dsx.sample(
+        "f",
+        dynamics,
+        obs_times=obs_times,
+        obs_values=obs_values,
+        missing_obs_metadata=metadata,
+    )
+
+predictive = jax.jit(Predictive(conditioned_model, num_samples=10))
+with dsx.LatentPathBuilder():
+    result = predictive(
+        prediction_key,
+        obs_times=obs_times,
+        obs_values=obs_values,
+    )
+```
+
+Observation times and finite values can change. The missing-observation layout
+must agree with the cached or supplied layout. If you supply one metadata
+object, all plate members use its layout.
+
+For plate members with different layouts, use one builder for all traced calls.
+Ragged `LatentStateResult` fields are flat lists of per-member arrays. Each
+NumPyro site keeps its shape, and the rightmost plate index varies fastest.
 
 ## Implementation Details 
 

--- a/dynestyx/__init__.py
+++ b/dynestyx/__init__.py
@@ -37,6 +37,10 @@ from dynestyx.models import (
     ScalarDiffusion,
     StochasticContinuousTimeStateEvolution,
 )
+from dynestyx.observation_missingness import (
+    MissingObservationMetadata,
+    prepare_missing_observation_metadata,
+)
 from dynestyx.simulation import (
     DiscreteTimeSimulator,
     ODESimulator,
@@ -67,6 +71,7 @@ __all__ = [
     "ObservationModel",
     "Filter",
     "LatentPathBuilder",
+    "MissingObservationMetadata",
     "Smoother",
     "flatten_draws",
     "condition",
@@ -74,6 +79,7 @@ __all__ = [
     "SimulatedResult",
     "log_prob",
     "plate",
+    "prepare_missing_observation_metadata",
     "sample",
     "simulate",
     "DiracIdentityObservation",

--- a/dynestyx/inference/checkers.py
+++ b/dynestyx/inference/checkers.py
@@ -104,15 +104,10 @@ def _validate_batched_plate_alignment(
 def _validate_missing_observation_support(
     config: BaseFilterConfig | BaseSmootherConfig,
     *,
-    obs_values: Real[Array, "*obs_value_plate obs_time observation_dim"]
-    | Real[Array, "*obs_value_plate obs_time"]
-    | None,
+    obs_values: Real[Array, "*obs_value_shape"],
     mode: Literal["filter", "smoother"],
-) -> None:
+) -> Real[Array, "*obs_value_shape"]:
     """Reject unsupported NaN-valued observations for filter/smoother backends."""
-    if obs_values is None:
-        return
-
     has_missing = jnp.any(jnp.isnan(obs_values))
 
     if mode == "filter":
@@ -149,21 +144,19 @@ def _validate_missing_observation_support(
         )
 
     if isinstance(config, continuous_types):
-        _raise_now_or_error_if(obs_values, has_missing, cd_dynamax_msg)
-        return
+        return _raise_now_or_error_if(obs_values, has_missing, cd_dynamax_msg)
 
     if mode == "filter" and isinstance(config, HMMConfigs):
-        return
+        return obs_values
 
     if isinstance(config, discrete_types):
         filter_source = getattr(config, "filter_source", None)
         if filter_source == "cd_dynamax":
-            _raise_now_or_error_if(obs_values, has_missing, cd_dynamax_msg)
-            return
+            return _raise_now_or_error_if(obs_values, has_missing, cd_dynamax_msg)
 
         if filter_source == "cuthbert":
             if mode == "filter" and isinstance(config, PFConfig):
-                _raise_now_or_error_if(
+                return _raise_now_or_error_if(
                     obs_values,
                     has_missing,
                     "PFConfig does not treat NaN-valued obs_values specially. "
@@ -172,17 +165,15 @@ def _validate_missing_observation_support(
                     "handle NaNs appropriately.",
                     action="warn",
                 )
-                return
             if isinstance(config, exact_supported_types):
-                return
-            _raise_now_or_error_if(
+                return obs_values
+            return _raise_now_or_error_if(
                 obs_values,
                 has_missing,
                 exact_supported_msg,
             )
-            return
 
-    _raise_now_or_error_if(
+    return _raise_now_or_error_if(
         obs_values,
         has_missing,
         f"NaN-valued obs_values are not supported for {type(config).__name__} {fallback_label}s.",

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -203,7 +203,7 @@ class Filter(BaseLogFactorAdder):
     There are several different filters available in `dynestyx`, each with their own strengths and weaknesses.
     What filters are applicable to a given model depends heavily on any special structure of the model (for example, linear and/or Gaussian observations).
     For a summary table of all config classes and when to use them, see
-    [Available filter configurations](filter_configs.md).
+    [Available filter configurations](configs/filter_configs.md).
 
     Defaults
     --------

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -270,7 +270,7 @@ class Filter(BaseLogFactorAdder):
             else _default_filter_config(dynamics)
         )
         if isinstance(config, BaseFilterConfig):
-            _validate_missing_observation_support(
+            obs_values = _validate_missing_observation_support(
                 config,
                 obs_values=obs_values,
                 mode="filter",

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -74,7 +74,7 @@ from dynestyx.types import (
     FunctionOfTime,
     chain_numpyro_site_registrations,
 )
-from dynestyx.utils import _dist_has_plate_batch_dims, _should_record_field
+from dynestyx.utils import _dist_has_plate_batch_dims
 
 type SSMType = ContDiscreteNonlinearGaussianSSM | ContDiscreteNonlinearSSM
 
@@ -377,17 +377,18 @@ class Filter(BaseLogFactorAdder):
         def _register(site_name: str) -> None:
             if marginal_loglik is None or config is None:
                 return
-            if _is_batched:
-                # TODO: support per-field recording for batched (plate) states
-                numpyro.factor(f"{site_name}_marginal_log_likelihood", marginal_loglik)
-                numpyro.deterministic(f"{site_name}_marginal_loglik", marginal_loglik)
-            elif isinstance(config, HMMConfigs):
+            if isinstance(config, HMMConfigs):
+                log_filt_seq = cast(tuple, states)[1] if _is_batched else states
                 register_hmm_filter_sites(
                     site_name,
                     marginal_loglik,
-                    cast(jax.Array, states),
+                    cast(jax.Array, log_filt_seq),
                     cast(HMMConfig, config),
                 )
+            elif _is_batched:
+                # TODO: support per-field recording for batched (plate) states
+                numpyro.factor(f"{site_name}_marginal_log_likelihood", marginal_loglik)
+                numpyro.deterministic(f"{site_name}_marginal_loglik", marginal_loglik)
             else:
                 register_filter_sites(site_name, marginal_loglik, states, config)
 
@@ -646,23 +647,6 @@ class Filter(BaseLogFactorAdder):
                 ),
             )
         if output_kind == "hmm":
-            hmm_config = cast(HMMConfig, config)
-            record_max_elems = hmm_config.record_max_elems
-            if _should_record_field(
-                hmm_config.record_log_filtered,
-                log_filt_seq.shape,
-                record_max_elems,
-            ):
-                numpyro.deterministic(f"{name}_log_filtered_states", log_filt_seq)
-            if _should_record_field(
-                hmm_config.record_filtered,
-                log_filt_seq.shape,
-                record_max_elems,
-            ):
-                numpyro.deterministic(
-                    f"{name}_filtered_states",
-                    jnp.exp(log_filt_seq),
-                )
             return _categorical_log_probs_to_dists(
                 log_filt_seq,
                 plate_shapes=plate_shapes,

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -100,6 +100,7 @@ class BaseLogFactorAdder(ObjectInterpretation, HandlesSelf, ABC):
         **kwargs,
     ) -> FunctionOfTime:
         filtered_dists = None
+        self.marginal_loglik = self.filtered_states = self._filter_config_used = None
         if not (obs_times is None or obs_values is None):
             filtered_dists = self._add_log_factors(
                 name,

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -668,12 +668,11 @@ def _filter_discrete_time(
     filter_config: BaseFilterConfig,
     key: PRNGKeyArray | None = None,
     *,
-    obs_times: Real[Array, "*obs_time_plate obs_time"],
-    obs_values: Real[Array, "*obs_value_plate obs_time observation_dim"]
-    | Real[Array, "*obs_value_plate obs_time"],
-    ctrl_times: Real[Array, "*ctrl_time_plate ctrl_time"] | None = None,
-    ctrl_values: Real[Array, "*ctrl_value_plate ctrl_time control_dim"]
-    | Real[Array, "*ctrl_value_plate ctrl_time"]
+    obs_times: Real[Array, " obs_time"],
+    obs_values: Real[Array, "obs_time observation_dim"] | Real[Array, " obs_time"],
+    ctrl_times: Real[Array, " ctrl_time"] | None = None,
+    ctrl_values: Real[Array, "ctrl_time control_dim"]
+    | Real[Array, " ctrl_time"]
     | None = None,
     **kwargs,
 ) -> tuple[jax.Array | None, object | None, list[numpyro.distributions.Distribution]]:
@@ -725,12 +724,11 @@ def _filter_continuous_time(
     filter_config: BaseFilterConfig,
     key: PRNGKeyArray | None = None,
     *,
-    obs_times: Real[Array, "*obs_time_plate obs_time"],
-    obs_values: Real[Array, "*obs_value_plate obs_time observation_dim"]
-    | Real[Array, "*obs_value_plate obs_time"],
-    ctrl_times: Real[Array, "*ctrl_time_plate ctrl_time"] | None = None,
-    ctrl_values: Real[Array, "*ctrl_value_plate ctrl_time control_dim"]
-    | Real[Array, "*ctrl_value_plate ctrl_time"]
+    obs_times: Real[Array, " obs_time"],
+    obs_values: Real[Array, "obs_time observation_dim"] | Real[Array, " obs_time"],
+    ctrl_times: Real[Array, " ctrl_time"] | None = None,
+    ctrl_values: Real[Array, "ctrl_time control_dim"]
+    | Real[Array, " ctrl_time"]
     | None = None,
     **kwargs,
 ) -> tuple[jax.Array, object, list[numpyro.distributions.Distribution]]:

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -378,11 +378,10 @@ class Filter(BaseLogFactorAdder):
             if marginal_loglik is None or config is None:
                 return
             if isinstance(config, HMMConfigs):
-                log_filt_seq = cast(tuple, states)[1] if _is_batched else states
                 register_hmm_filter_sites(
                     site_name,
                     marginal_loglik,
-                    cast(jax.Array, log_filt_seq),
+                    cast(jax.Array, states),
                     cast(HMMConfig, config),
                 )
             elif _is_batched:
@@ -612,15 +611,17 @@ class Filter(BaseLogFactorAdder):
 
         if output_kind in {"continuous", "cd_dynamax_discrete"}:
             marginal_logliks = outputs.marginal_loglik
+            states = outputs
         elif output_kind == "hmm":
-            marginal_logliks, log_filt_seq = outputs
+            marginal_logliks, states = outputs
+            log_filt_seq = states
         elif output_kind == "cuthbert":
             marginal_logliks, states = outputs
         else:
             raise ValueError(f"Unsupported batched output kind: {output_kind}")
 
         self.marginal_loglik = marginal_logliks
-        self.filtered_states = outputs
+        self.filtered_states = states
         self._filter_config_used = config
 
         if output_kind == "continuous":

--- a/dynestyx/inference/latent/builder.py
+++ b/dynestyx/inference/latent/builder.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+import dataclasses
 import itertools
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 from effectful.ops.semantics import fwd
 from effectful.ops.syntax import ObjectInterpretation, implements
-from jax.core import Tracer
 from jaxtyping import Array, Bool, Int, PRNGKeyArray, Real
 
 from dynestyx.handlers import HandlesSelf, _condition_intp
@@ -58,67 +59,37 @@ from dynestyx.simulation.utils import _sample_observation_path
 from dynestyx.types import LatentStateResult
 from dynestyx.utils import _build_control_path_eval
 
-_MISSING_OBSERVATION_METADATA_CACHE: dict[
-    tuple[str, str, tuple[int, ...], MissingObservationStrategy],
-    MissingObservationMetadata,
-] = {}
-
 
 def _resolve_missing_observation_metadata(
     *,
-    name: str,
-    role: str,
     dynamics: DynamicalModel,
     obs_times: Real[Array, " obs_time"],
     obs_values: Real[Array, "obs_time observation_dim"] | Real[Array, " obs_time"],
-    obs_mask: Bool[Array, "obs_time observation_dim"] | Bool[Array, " obs_time"],
-    strategy: MissingObservationStrategy,
 ) -> MissingObservationMetadata:
-    """Return missing-observation metadata for concrete or traced inputs.
-
-    Concrete inputs create and cache the metadata. Traced inputs reuse a
-    compatible cached value.
-
-    Args:
-        name: Name of the `dsx.sample(...)` site.
-        role: Purpose of the latent values. This value separates cache entries
-            that belong to the same sample site.
-        dynamics: Dynamical model associated with the observations.
-        obs_times: Observation times.
-        obs_values: Observation values. Their shape identifies the cache entry.
-        obs_mask: Boolean array that marks observed entries.
-        strategy: Requested missing-observation strategy.
-
-    Returns:
-        MissingObservationMetadata: Prepared metadata for the observation mask.
-
-    Raises:
-        ValueError: If traced inputs have no compatible cached metadata, or if
-            the cached observation shape does not match `obs_values`.
-    """
-    cache_key = (name, role, tuple(obs_values.shape), strategy)
-    if any(isinstance(value, Tracer) for value in (obs_times, obs_values, obs_mask)):
-        metadata = _MISSING_OBSERVATION_METADATA_CACHE.get(cache_key)
-        if metadata is None:
-            raise ValueError(
-                "LatentPathBuilder encountered traced observation missingness before "
-                "a compatible concrete model execution. Run the model once with "
-                "concrete obs_times/obs_values before traced replay."
+    """Prepare static missingness layout while retaining the current times."""
+    try:
+        with jax.ensure_compile_time_eval():
+            metadata = prepare_missing_observation_metadata(
+                dynamics,
+                obs_times=jnp.arange(obs_values.shape[0]),
+                obs_values=obs_values,
             )
-        if metadata.observation_shape != tuple(obs_values.shape):
-            raise ValueError(
-                "Cached LatentPathBuilder missingness metadata does not match the "
-                "current observation shape."
-            )
-        return metadata
+    except ValueError as exc:
+        if not isinstance(exc.__cause__, jax.errors.TracerArrayConversionError):
+            raise
+        raise ValueError(
+            "LatentPathBuilder requires a fixed observation missingness pattern "
+            "while tracing. Close over obs_values instead of passing it as a "
+            "dynamic jax.jit argument."
+        ) from exc
 
-    metadata = prepare_missing_observation_metadata(
-        dynamics,
-        obs_times=obs_times,
-        obs_mask=obs_mask,
+    time_indices = metadata.missing_flat_indices
+    if len(metadata.observation_shape) > 1:
+        time_indices = time_indices // metadata.observation_shape[-1]
+    return dataclasses.replace(
+        metadata,
+        missing_obs_times=jnp.take(obs_times, time_indices, axis=0),
     )
-    _MISSING_OBSERVATION_METADATA_CACHE[cache_key] = metadata
-    return metadata
 
 
 def _sample_missing_observation_prior(
@@ -343,13 +314,9 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
             )
 
         metadata = _resolve_missing_observation_metadata(
-            name=name,
-            role="observations",
             dynamics=dynamics,
             obs_times=obs_times,
             obs_values=obs_values,
-            obs_mask=obs_mask,
-            strategy=self.missing_observation_strategy,
         )
         exact_observations = isinstance(
             dynamics.observation_model,
@@ -658,6 +625,10 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
             member_results: list[LatentStateResult] = []
             for plate_idx in itertools.product(*[range(size) for size in plate_shapes]):
                 member_name = f"{name}_p{'_'.join(str(i) for i in plate_idx)}"
+                with jax.ensure_compile_time_eval():
+                    member_obs_values = _slice_array_for_plate_member(
+                        obs_values, plate_shapes, plate_idx
+                    )
                 with _suspend_numpyro_plate_frames():
                     member_results.append(
                         self._sample_single(
@@ -670,9 +641,7 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
                             obs_times=_slice_array_for_plate_member(
                                 obs_times, plate_shapes, plate_idx
                             ),
-                            obs_values=_slice_array_for_plate_member(
-                                obs_values, plate_shapes, plate_idx
-                            ),
+                            obs_values=member_obs_values,
                             obs_values_filled=_slice_array_for_plate_member(
                                 _obs_values_filled, plate_shapes, plate_idx
                             ),

--- a/dynestyx/inference/latent/builder.py
+++ b/dynestyx/inference/latent/builder.py
@@ -59,29 +59,50 @@ from dynestyx.simulation.utils import _sample_observation_path
 from dynestyx.types import LatentStateResult
 from dynestyx.utils import _build_control_path_eval
 
+_MissingObservationMetadataCache = dict[
+    tuple[str, tuple[int, ...]],
+    MissingObservationMetadata,
+]
+
 
 def _resolve_missing_observation_metadata(
     *,
+    name: str,
     dynamics: DynamicalModel,
     obs_times: Real[Array, " obs_time"],
     obs_values: Real[Array, "obs_time observation_dim"] | Real[Array, " obs_time"],
+    missing_obs_metadata: MissingObservationMetadata | None,
+    cache: _MissingObservationMetadataCache,
 ) -> MissingObservationMetadata:
     """Prepare static missingness layout while retaining the current times."""
-    try:
-        with jax.ensure_compile_time_eval():
-            metadata = prepare_missing_observation_metadata(
-                dynamics,
-                obs_times=jnp.arange(obs_values.shape[0]),
-                obs_values=obs_values,
-            )
-    except ValueError as exc:
-        if not isinstance(exc.__cause__, jax.errors.TracerArrayConversionError):
-            raise
+    cache_key = (name, tuple(obs_values.shape))
+    metadata = missing_obs_metadata
+    if metadata is None:
+        try:
+            with jax.ensure_compile_time_eval():
+                metadata = prepare_missing_observation_metadata(
+                    dynamics,
+                    obs_times=jnp.arange(obs_values.shape[0]),
+                    obs_values=obs_values,
+                )
+        except ValueError as exc:
+            if not isinstance(exc.__cause__, jax.errors.TracerArrayConversionError):
+                raise
+            metadata = cache.get(cache_key)
+            if metadata is None:
+                raise ValueError(
+                    f"LatentPathBuilder sample site {name!r} needs a fixed "
+                    "observation missingness pattern, but cannot infer one from "
+                    "traced obs_values. Reuse a builder that has first seen concrete "
+                    "observations, or pass metadata prepared with "
+                    "dsx.prepare_missing_observation_metadata(...) to "
+                    "dsx.sample(..., missing_obs_metadata=...)."
+                ) from exc
+    if metadata.observation_shape != tuple(obs_values.shape):
         raise ValueError(
-            "LatentPathBuilder requires a fixed observation missingness pattern "
-            "while tracing. Close over obs_values instead of passing it as a "
-            "dynamic jax.jit argument."
-        ) from exc
+            "missing_obs_metadata.observation_shape must match obs_values.shape."
+        )
+    cache[cache_key] = metadata
 
     time_indices = metadata.missing_flat_indices
     if len(metadata.observation_shape) > 1:
@@ -186,6 +207,13 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
     inferred through `state_path_params`, and missing data support only
     `"auto"` or `"augment"`.
 
+    A missingness layout can determine NumPyro site shapes. The builder infers
+    and caches this layout whenever observations are concrete. Before an outer
+    `jax.jit` passes `obs_values` dynamically, either reuse a builder that has
+    seen concrete observations or pass eagerly prepared `missing_obs_metadata`
+    to `dsx.sample(...)`. JAX itself does not run the function eagerly before
+    tracing.
+
     Attributes:
         ode_simulator_config: ODE solver and integration settings used during
             deterministic continuous-time path reconstruction.
@@ -197,7 +225,8 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
             evaluates batches of that size with `jax.vmap`.
 
     Examples:
-        >>> with dsx.LatentPathBuilder():
+        >>> builder = dsx.LatentPathBuilder()
+        >>> with builder:
         ...     result = dsx.sample(
         ...         "f",
         ...         dynamics,
@@ -232,6 +261,7 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
         self.ode_simulator_config = ode_simulator_config
         self.missing_observation_strategy = missing_observation_strategy
         self.chunk_size = chunk_size
+        self._missing_observation_metadata_cache: _MissingObservationMetadataCache = {}
 
     def _sample_single(
         self,
@@ -248,6 +278,7 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
         obs_mask: Bool[Array, "obs_time observation_dim"]
         | Bool[Array, " obs_time"]
         | None,
+        missing_obs_metadata: MissingObservationMetadata | None,
         ctrl_times: Real[Array, " ctrl_time"] | None,
         ctrl_values: Real[Array, "ctrl_time control_dim"]
         | Real[Array, " ctrl_time"]
@@ -265,6 +296,7 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
             obs_values_filled: Observation values with missing entries replaced
                 by shape-preserving filler values.
             obs_mask: Boolean array that marks observed entries.
+            missing_obs_metadata: Optional concrete missingness layout.
             ctrl_times: Times associated with `ctrl_values`.
             ctrl_values: Control values, or `None` for an uncontrolled model.
             state_path_params: State values used to construct the path. `None`
@@ -314,9 +346,24 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
             )
 
         metadata = _resolve_missing_observation_metadata(
+            name=name,
             dynamics=dynamics,
             obs_times=obs_times,
             obs_values=obs_values,
+            missing_obs_metadata=missing_obs_metadata,
+            cache=self._missing_observation_metadata_cache,
+        )
+        expected_obs_mask = (
+            jnp.ones((obs_values.size,), dtype=bool)
+            .at[metadata.missing_flat_indices]
+            .set(False)
+            .reshape(obs_values.shape)
+        )
+        obs_values_filled = eqx.error_if(
+            obs_values_filled,
+            jnp.any(obs_mask != expected_obs_mask),
+            f"obs_values missingness for sample site {name!r} does not match "
+            "the LatentPathBuilder layout.",
         )
         exact_observations = isinstance(
             dynamics.observation_model,
@@ -559,6 +606,7 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
         | Bool[Array, "*obs_value_plate obs_time"]
         | None = None,
         _obs_has_missing: bool | None = None,
+        missing_obs_metadata: MissingObservationMetadata | None = None,
         ctrl_times: Real[Array, "*ctrl_time_plate ctrl_time"] | None = None,
         ctrl_values: Real[Array, "*ctrl_value_plate ctrl_time control_dim"]
         | Real[Array, "*ctrl_value_plate ctrl_time"]
@@ -582,6 +630,8 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
             _obs_mask: Internal boolean array that marks observed entries.
             _obs_has_missing: Internal flag indicating whether any observations
                 are missing.
+            missing_obs_metadata: Optional concrete missingness layout. One
+                layout is shared by all plate members.
             ctrl_times: Times associated with `ctrl_values`.
             ctrl_values: Control values, or `None` for an uncontrolled model.
             predict_times: Future times used for posterior rollout. Each time
@@ -616,6 +666,7 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
                 obs_values=obs_values,
                 obs_values_filled=_obs_values_filled,
                 obs_mask=_obs_mask,
+                missing_obs_metadata=missing_obs_metadata,
                 ctrl_times=ctrl_times,
                 ctrl_values=ctrl_values,
                 state_path_params=state_path_params,
@@ -625,10 +676,9 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
             member_results: list[LatentStateResult] = []
             for plate_idx in itertools.product(*[range(size) for size in plate_shapes]):
                 member_name = f"{name}_p{'_'.join(str(i) for i in plate_idx)}"
-                with jax.ensure_compile_time_eval():
-                    member_obs_values = _slice_array_for_plate_member(
-                        obs_values, plate_shapes, plate_idx
-                    )
+                member_obs_values = _slice_array_for_plate_member(
+                    obs_values, plate_shapes, plate_idx
+                )
                 with _suspend_numpyro_plate_frames():
                     member_results.append(
                         self._sample_single(
@@ -648,6 +698,7 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
                             obs_mask=_slice_array_for_plate_member(
                                 _obs_mask, plate_shapes, plate_idx
                             ),
+                            missing_obs_metadata=missing_obs_metadata,
                             ctrl_times=_slice_array_for_plate_member(
                                 ctrl_times, plate_shapes, plate_idx
                             ),

--- a/dynestyx/inference/latent/builder.py
+++ b/dynestyx/inference/latent/builder.py
@@ -38,6 +38,7 @@ from dynestyx.inference.utils.plate_utils import (
     _slice_array_for_plate_member,
     _slice_dynamics_for_plate_member,
     _stack_optional_member_values,
+    _stack_or_list_optional_member_values,
     _suspend_numpyro_plate_frames,
 )
 from dynestyx.models import (
@@ -714,40 +715,48 @@ class LatentPathBuilder(ObjectInterpretation, HandlesSelf):
                         )
                     )
 
-            stacked_member_values = {
+            dense_member_values = {
                 attr: _stack_optional_member_values(
                     [getattr(member, attr) for member in member_results],
                     plate_shapes,
                 )
                 for attr in (
                     "joint_log_prob",
-                    "state_path_params",
-                    "state_path_param_times",
-                    "state_path_param_coordinate_indices",
                     "state_path",
                     "state_path_times",
-                    "missing_obs_values",
-                    "missing_obs_times",
-                    "missing_obs_coordinate_indices",
                     "completed_obs_values",
                 )
             }
-            state_path = stacked_member_values["state_path"]
+            ragged_member_values = {
+                attr: _stack_or_list_optional_member_values(
+                    [getattr(member, attr) for member in member_results],
+                    plate_shapes,
+                )
+                for attr in (
+                    "state_path_params",
+                    "state_path_param_times",
+                    "state_path_param_coordinate_indices",
+                    "missing_obs_values",
+                    "missing_obs_times",
+                    "missing_obs_coordinate_indices",
+                )
+            }
+            state_path = dense_member_values["state_path"]
             result = LatentStateResult(
-                joint_log_prob=stacked_member_values["joint_log_prob"],
-                state_path_params=stacked_member_values["state_path_params"],
-                state_path_param_times=stacked_member_values["state_path_param_times"],
-                state_path_param_coordinate_indices=stacked_member_values[
+                joint_log_prob=dense_member_values["joint_log_prob"],
+                state_path_params=ragged_member_values["state_path_params"],
+                state_path_param_times=ragged_member_values["state_path_param_times"],
+                state_path_param_coordinate_indices=ragged_member_values[
                     "state_path_param_coordinate_indices"
                 ],
                 state_path=state_path,
-                state_path_times=stacked_member_values["state_path_times"],
-                missing_obs_values=stacked_member_values["missing_obs_values"],
-                missing_obs_times=stacked_member_values["missing_obs_times"],
-                missing_obs_coordinate_indices=stacked_member_values[
+                state_path_times=dense_member_values["state_path_times"],
+                missing_obs_values=ragged_member_values["missing_obs_values"],
+                missing_obs_times=ragged_member_values["missing_obs_times"],
+                missing_obs_coordinate_indices=ragged_member_values[
                     "missing_obs_coordinate_indices"
                 ],
-                completed_obs_values=stacked_member_values["completed_obs_values"],
+                completed_obs_values=dense_member_values["completed_obs_values"],
                 state_dists=(
                     None
                     if state_path is None

--- a/dynestyx/inference/posterior_rollout.py
+++ b/dynestyx/inference/posterior_rollout.py
@@ -19,12 +19,11 @@ def _validate_future_only_predict_times(
     if predict_times is None or anchor_times is None:
         return predict_times
     anchor_end = anchor_times[..., -1:]
-    _ = eqx.error_if(
+    return eqx.error_if(
         predict_times,
         jnp.any(predict_times < anchor_end),
         error_message,
     )
-    return predict_times
 
 
 def _final_times_for_rollout(

--- a/dynestyx/inference/smoothers.py
+++ b/dynestyx/inference/smoothers.py
@@ -137,6 +137,7 @@ class BaseSmootherLogFactorAdder(ObjectInterpretation, HandlesSelf, ABC):
         filtered_dists = None
         posterior_rollout_final_only = False
         smoothed_times = obs_times
+        result_smoothed_dists = smoothed_dists
         if predict_times is not None and smoothed_dists:
             assert obs_times is not None
             filtered_times = _final_times_for_rollout(obs_times)
@@ -163,7 +164,7 @@ class BaseSmootherLogFactorAdder(ObjectInterpretation, HandlesSelf, ABC):
             **kwargs,
         )
 
-        result = self._build_infer_result(name, smoothed_dists)
+        result = self._build_infer_result(name, result_smoothed_dists)
         forwarded_register = getattr(forwarded_result, "_register_numpyro_sites", None)
         result._register_numpyro_sites = chain_numpyro_site_registrations(
             result._register_numpyro_sites,

--- a/dynestyx/inference/smoothers.py
+++ b/dynestyx/inference/smoothers.py
@@ -111,6 +111,7 @@ class BaseSmootherLogFactorAdder(ObjectInterpretation, HandlesSelf, ABC):
         **kwargs,
     ) -> FunctionOfTime:
         smoothed_dists = None
+        self.marginal_loglik = self.smoothed_states = self._smoother_config_used = None
         if not (obs_times is None or obs_values is None):
             smoothed_dists = self._add_log_factors(
                 name,

--- a/dynestyx/inference/smoothers.py
+++ b/dynestyx/inference/smoothers.py
@@ -558,12 +558,11 @@ def _smooth_discrete_time(
     smoother_config: DiscreteSmootherConfig,
     key: PRNGKeyArray | None = None,
     *,
-    obs_times: Real[Array, "*obs_time_plate obs_time"],
-    obs_values: Real[Array, "*obs_value_plate obs_time observation_dim"]
-    | Real[Array, "*obs_value_plate obs_time"],
-    ctrl_times: Real[Array, "*ctrl_time_plate ctrl_time"] | None = None,
-    ctrl_values: Real[Array, "*ctrl_value_plate ctrl_time control_dim"]
-    | Real[Array, "*ctrl_value_plate ctrl_time"]
+    obs_times: Real[Array, " obs_time"],
+    obs_values: Real[Array, "obs_time observation_dim"] | Real[Array, " obs_time"],
+    ctrl_times: Real[Array, " ctrl_time"] | None = None,
+    ctrl_values: Real[Array, "ctrl_time control_dim"]
+    | Real[Array, " ctrl_time"]
     | None = None,
     **kwargs,
 ) -> tuple[jax.Array | None, object | None, list[numpyro.distributions.Distribution]]:
@@ -626,12 +625,11 @@ def _smooth_continuous_time(
     smoother_config: ContinuousSmootherConfig,
     key: PRNGKeyArray | None = None,
     *,
-    obs_times: Real[Array, "*obs_time_plate obs_time"],
-    obs_values: Real[Array, "*obs_value_plate obs_time observation_dim"]
-    | Real[Array, "*obs_value_plate obs_time"],
-    ctrl_times: Real[Array, "*ctrl_time_plate ctrl_time"] | None = None,
-    ctrl_values: Real[Array, "*ctrl_value_plate ctrl_time control_dim"]
-    | Real[Array, "*ctrl_value_plate ctrl_time"]
+    obs_times: Real[Array, " obs_time"],
+    obs_values: Real[Array, "obs_time observation_dim"] | Real[Array, " obs_time"],
+    ctrl_times: Real[Array, " ctrl_time"] | None = None,
+    ctrl_values: Real[Array, "ctrl_time control_dim"]
+    | Real[Array, " ctrl_time"]
     | None = None,
     **kwargs,
 ) -> tuple[jax.Array, object, list[numpyro.distributions.Distribution]]:

--- a/dynestyx/inference/smoothers.py
+++ b/dynestyx/inference/smoothers.py
@@ -244,7 +244,7 @@ class Smoother(BaseSmootherLogFactorAdder):
                 "Expected a smoother config class from dynestyx.inference.configs.smoother. "
                 f"Valid types: {valid}"
             )
-        _validate_missing_observation_support(
+        obs_values = _validate_missing_observation_support(
             config,
             obs_values=obs_values,
             mode="smoother",

--- a/dynestyx/inference/smoothers.py
+++ b/dynestyx/inference/smoothers.py
@@ -510,13 +510,14 @@ class Smoother(BaseSmootherLogFactorAdder):
 
         if output_kind in {"continuous", "cd_dynamax_discrete"}:
             marginal_logliks = outputs.marginal_loglik
+            states = outputs
         elif output_kind == "cuthbert":
             marginal_logliks, states = outputs
         else:
             raise ValueError(f"Unsupported batched output kind: {output_kind}")
 
         self.marginal_loglik = marginal_logliks
-        self.smoothed_states = outputs
+        self.smoothed_states = states
         self._smoother_config_used = config
 
         if output_kind == "continuous":

--- a/dynestyx/inference/state_paths/score.py
+++ b/dynestyx/inference/state_paths/score.py
@@ -211,7 +211,7 @@ def compute_state_path_log_prob(
             )
 
     if obs_times is None or obs_values is None:
-        return initial_log_prob + jnp.sum(transition_log_probs)
+        return initial_log_prob + jnp.sum(transition_log_probs, axis=0)
 
     state_at_obs_times = _gather_by_exact_time(
         state_path,
@@ -220,7 +220,7 @@ def compute_state_path_log_prob(
         value_name="state_path",
     )
     if observations_are_exact_constraints:
-        return initial_log_prob + jnp.sum(transition_log_probs)
+        return initial_log_prob + jnp.sum(transition_log_probs, axis=0)
 
     obs_ctrl_values = _control_values_at_times(ctrl_times, ctrl_values, obs_times)
     observation_log_prob, _, _, _ = prepare_observation_log_prob(
@@ -256,8 +256,8 @@ def compute_state_path_log_prob(
 
     return (
         initial_log_prob
-        + jnp.sum(transition_log_probs)
-        + jnp.sum(observation_log_probs)
+        + jnp.sum(transition_log_probs, axis=0)
+        + jnp.sum(observation_log_probs, axis=0)
     )
 
 

--- a/dynestyx/inference/state_paths/score.py
+++ b/dynestyx/inference/state_paths/score.py
@@ -52,8 +52,8 @@ def _gather_by_exact_time(
     max_idx = source.shape[0] - 1
     safe_idx = jnp.clip(idx, 0, max_idx)
     matched = (idx < source.shape[0]) & (source[safe_idx] == query)
-    _ = eqx.error_if(
-        query,
+    safe_idx = eqx.error_if(
+        safe_idx,
         jnp.any(~matched),
         f"{value_name} must be defined exactly at every requested query time.",
     )

--- a/dynestyx/inference/utils/plate_utils.py
+++ b/dynestyx/inference/utils/plate_utils.py
@@ -282,7 +282,7 @@ def _stack_optional_member_values(
 
     Args:
         values: One value per plate member, ordered by flattened plate index.
-            Each non-`None` value must have the same shape.
+            Non-`None` values must have broadcast-compatible shapes.
         plate_shapes: Sizes of the plate dimensions to restore.
 
     Returns:
@@ -292,8 +292,9 @@ def _stack_optional_member_values(
     """
     if any(value is None for value in values):
         return None
-    first = jnp.asarray(values[0])
-    return jnp.stack([jnp.asarray(value) for value in values]).reshape(
+    arrays = jnp.broadcast_arrays(*[jnp.asarray(value) for value in values])
+    first = arrays[0]
+    return jnp.stack(arrays).reshape(
         *plate_shapes,
         *first.shape,
     )

--- a/dynestyx/inference/utils/plate_utils.py
+++ b/dynestyx/inference/utils/plate_utils.py
@@ -300,6 +300,37 @@ def _stack_optional_member_values(
     )
 
 
+def _stack_or_list_optional_member_values(
+    values: list[Shaped[Array, "..."] | None],
+    plate_shapes: tuple[int, ...],
+) -> Shaped[Array, "..."] | list[Shaped[Array, "..."]] | None:
+    """Stack uniform member values or preserve ragged values as a flat list.
+
+    The list order matches ``itertools.product`` over ``plate_shapes``: the
+    rightmost plate index varies fastest.
+
+    Args:
+        values: One value per flattened plate member.
+        plate_shapes: Sizes of the plate dimensions to restore for uniform
+            values.
+
+    Returns:
+        Array | list[Array] | None: A stacked array when all member shapes
+            match, the original member arrays when their shapes differ, or
+            `None` if any member value is `None`.
+    """
+    if any(value is None for value in values):
+        return None
+    arrays = [jnp.asarray(value) for value in values]
+    if any(array.shape != arrays[0].shape for array in arrays[1:]):
+        return arrays
+    first = arrays[0]
+    return jnp.stack(arrays).reshape(
+        *plate_shapes,
+        *first.shape,
+    )
+
+
 @contextmanager
 def _suspend_numpyro_plate_frames():
     """Temporarily remove active NumPyro plate frames.

--- a/dynestyx/observation_missingness.py
+++ b/dynestyx/observation_missingness.py
@@ -363,20 +363,21 @@ def prepare_observation_views(
         invalid_mask,
         concrete_message,
         traced_message,
-    ) -> None:
+    ) -> Array:
         try:
             has_invalid = bool(jnp.any(invalid_mask))
         except TracerBoolConversionError:
-            _raise_now_or_error_if(obs_arr, jnp.any(invalid_mask), traced_message)
-            return
+            return _raise_now_or_error_if(
+                obs_arr, jnp.any(invalid_mask), traced_message
+            )
 
         if not has_invalid:
-            return
+            return obs_arr
 
         bad = obs_arr[invalid_mask][0]
         raise ValueError(concrete_message(bad))
 
-    _raise_categorical_validation_error(
+    obs_arr = _raise_categorical_validation_error(
         obs_mask & ~jnp.equal(obs_arr, jnp.round(obs_arr)),
         lambda bad: (
             "Categorical observations must be encoded as zero-based integer "
@@ -384,7 +385,7 @@ def prepare_observation_views(
         ),
         "Categorical observations must be encoded as zero-based integer labels.",
     )
-    _raise_categorical_validation_error(
+    obs_arr = _raise_categorical_validation_error(
         obs_mask & (obs_arr < 0),
         lambda bad: (
             "Categorical observations must be encoded as zero-based integer "
@@ -394,7 +395,7 @@ def prepare_observation_views(
     )
 
     support_size = _categorical_support_size(obs_dist)
-    _raise_categorical_validation_error(
+    obs_arr = _raise_categorical_validation_error(
         obs_mask & (obs_arr >= support_size),
         lambda bad: (
             "Categorical observations must be encoded as zero-based integer "
@@ -691,7 +692,7 @@ def masked_observation_log_prob(
 
     if expected_mode == "masked":
         row_is_partial = row_has_any_observed & ~jnp.all(obs_mask)
-        _raise_now_or_error_if(
+        y = _raise_now_or_error_if(
             y,
             row_is_partial,
             "Partial missingness currently requires marginalizable "

--- a/dynestyx/simulation/discrete.py
+++ b/dynestyx/simulation/discrete.py
@@ -35,8 +35,8 @@ def _align_ctrl_values_to_times(
     max_idx = ctrl_times.shape[0] - 1
     safe_idx = jnp.clip(idx, 0, max_idx)
     matched = (idx < ctrl_times.shape[0]) & (ctrl_times[safe_idx] == times)
-    _raise_now_or_error_if(
-        times,
+    safe_idx = _raise_now_or_error_if(
+        safe_idx,
         jnp.any(~matched),
         "ctrl_times must contain every discrete simulation time exactly.",
     )

--- a/dynestyx/types.py
+++ b/dynestyx/types.py
@@ -64,26 +64,40 @@ class LatentStateResult:
       entries of ``obs_values``,
     - ``completed_obs_values`` is the dense observation array after those
       missing entries are filled back in.
+
+    Under plates, latent-coordinate fields are stacked when all members have
+    the same shape. Ragged values are returned as a flat list in plate order,
+    with the rightmost plate index varying fastest.
     """
 
     joint_log_prob: Real[Array, "*plate"] | None = None
-    state_path_params: Real[Array, "*state_path_param_shape"] | None = None
+    state_path_params: (
+        Real[Array, "*state_path_param_shape"] | list[Real[Array, "..."]] | None
+    ) = None
     state_path_param_times: (
-        Real[Array, "*state_path_param_time_plate state_path_param_time"] | None
+        Real[Array, "*state_path_param_time_plate state_path_param_time"]
+        | list[Real[Array, "..."]]
+        | None
     ) = None
     state_path_param_coordinate_indices: (
-        Int[Array, "*state_path_param_plate n_state_path_params"] | None
+        Int[Array, "*state_path_param_plate n_state_path_params"]
+        | list[Int[Array, "..."]]
+        | None
     ) = None
     state_path: Real[Array, "*state_path_shape"] | None = None
     state_path_times: Real[Array, "*state_path_time_plate state_path_time"] | None = (
         None
     )
-    missing_obs_values: Real[Array, "*missing_obs_shape"] | None = None
-    missing_obs_times: Real[Array, "*missing_obs_time_plate n_missing_obs"] | None = (
-        None
-    )
+    missing_obs_values: (
+        Real[Array, "*missing_obs_shape"] | list[Real[Array, "..."]] | None
+    ) = None
+    missing_obs_times: (
+        Real[Array, "*missing_obs_time_plate n_missing_obs"]
+        | list[Real[Array, "..."]]
+        | None
+    ) = None
     missing_obs_coordinate_indices: (
-        Int[Array, "*missing_obs_plate n_missing_obs"] | None
+        Int[Array, "*missing_obs_plate n_missing_obs"] | list[Int[Array, "..."]] | None
     ) = None
     completed_obs_values: Real[Array, "*completed_obs_shape"] | None = None
     state_dists: list | None = None

--- a/dynestyx/utils.py
+++ b/dynestyx/utils.py
@@ -45,26 +45,26 @@ _CONTROL_EXTEND_EPSILON = 1e-5
 
 
 def _raise_now_or_error_if(
-    anchor,
+    anchor: Array,
     predicate,
     message: str,
     *,
     action: Literal["raise", "warn"] = "raise",
-) -> None:
-    """Raise or warn when a predicate is true, handling traced predicates safely."""
+) -> Array:
+    """Raise or warn for a predicate, returning the anchor to preserve JIT checks."""
     try:
         should_handle = bool(predicate)
     except jax.errors.TracerBoolConversionError:
         if action == "raise":
-            _ = eqx.error_if(anchor, predicate, message)
-        return
+            return eqx.error_if(anchor, predicate, message)
+        return anchor
 
     if not should_handle:
-        return
+        return anchor
 
     if action == "warn":
         warnings.warn(message, stacklevel=2)
-        return
+        return anchor
 
     if action == "raise":
         raise ValueError(message)

--- a/dynestyx/utils.py
+++ b/dynestyx/utils.py
@@ -51,7 +51,11 @@ def _raise_now_or_error_if(
     *,
     action: Literal["raise", "warn"] = "raise",
 ) -> Array:
-    """Raise or warn for a predicate, returning the anchor to preserve JIT checks."""
+    """Raise or warn for a predicate, returning the anchor to preserve JIT checks.
+
+    Warnings are emitted only for eager predicates. A traced warning predicate
+    returns the anchor unchanged rather than introducing a JAX runtime callback.
+    """
     try:
         should_handle = bool(predicate)
     except jax.errors.TracerBoolConversionError:

--- a/tests/missingness/test_hmm.py
+++ b/tests/missingness/test_hmm.py
@@ -380,6 +380,7 @@ def test_plated_hmm_condition_defers_numpyro_sites():
                 )
 
     assert result.marginal_loglik.shape == (2,)
+    assert result.states.shape == (2, 3, 2)
     assert not any(site_name.startswith("f_") for site_name in tr)
 
 

--- a/tests/missingness/test_hmm.py
+++ b/tests/missingness/test_hmm.py
@@ -361,6 +361,26 @@ def test_plated_hmm_gaussian_missingness_matches_memberwise_filter():
     assert jnp.allclose(actual_filtered, jnp.exp(expected_log_filtered))
 
 
+def test_plated_hmm_condition_defers_numpyro_sites():
+    obs_times = jnp.arange(3.0)
+    obs_values = jnp.zeros((2, 3, 2))
+
+    with trace() as tr:
+        with Filter(
+            filter_config=HMMConfig(record_filtered=True, record_log_filtered=True)
+        ):
+            with dsx.plate("trajectories", 2):
+                result = dsx.condition(
+                    "f",
+                    _build_hmm_dynamics(_mvn_observation_model),
+                    obs_times=obs_times,
+                    obs_values=obs_values,
+                )
+
+    assert result.marginal_loglik.shape == (2,)
+    assert not any(site_name.startswith("f_") for site_name in tr)
+
+
 def test_plated_hmm_independent_categorical_missingness_matches_memberwise_filter():
     M = 2
     obs_times = jnp.arange(4.0)

--- a/tests/missingness/test_hmm.py
+++ b/tests/missingness/test_hmm.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpyro
@@ -11,6 +12,7 @@ from dynestyx import DiscreteTimeSimulator, Filter
 from dynestyx.inference.configs.filter import HMMConfig
 from dynestyx.inference.hmm_filters import compute_hmm_filter, hmm_log_components
 from dynestyx.models import DynamicalModel
+from dynestyx.observation_missingness import prepare_observation_views
 from tests.missingness.models import GAUSSIAN_R, INDEPENDENT_SCALE
 from tests.missingness.utils import (
     manual_masked_independent_normal_log_prob,
@@ -622,4 +624,24 @@ def test_hmm_categorical_observations_reject_out_of_range_labels_early():
             _build_hmm_dynamics(_joint_categorical_observation_model),
             obs_times,
             obs_values,
+        )
+
+
+@pytest.mark.parametrize(
+    ("bad_value", "error_match"),
+    [
+        pytest.param(1.5, "zero-based integer labels\\.", id="non-integer"),
+        pytest.param(-1.0, "zero-based integer labels 0..K-1", id="negative"),
+        pytest.param(4.0, "probed observation distribution with K=4", id="too-large"),
+    ],
+)
+def test_hmm_categorical_observation_guards_survive_jit(bad_value, error_match):
+    dynamics = _build_hmm_dynamics(_joint_categorical_observation_model)
+    obs_values = jnp.array([0.0, bad_value, 2.0])
+
+    with pytest.raises(Exception, match=error_match):
+        jax.block_until_ready(
+            jax.jit(lambda values: prepare_observation_views(dynamics, values)[0])(
+                obs_values
+            )
         )

--- a/tests/missingness/test_observation_log_prob.py
+++ b/tests/missingness/test_observation_log_prob.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import numpyro.distributions as dist
 import pytest
@@ -146,6 +147,22 @@ def test_observation_log_prob_partial_missing_unsupported_distribution_raises_at
             obs_values,
             missing_observation_strategy="marginalize",
         )
+
+
+def test_observation_log_prob_partial_missing_guard_survives_jit():
+    dynamics = _build_vector_dynamics(lambda x, u, t: dist.Delta(x, event_dim=1))
+
+    def score(obs_values):
+        log_prob, _, _, _ = prepare_observation_log_prob(dynamics, obs_values)
+        return log_prob(
+            x=jnp.zeros(2),
+            u=None,
+            t=jnp.array(0.0),
+            t_idx=0,
+        )
+
+    with pytest.raises(Exception, match="Partial missingness currently requires"):
+        jax.block_until_ready(jax.jit(score)(jnp.array([[0.0, jnp.nan]])))
 
 
 def test_observation_log_prob_partial_missing_type_change_raises_clear_error():

--- a/tests/test_filter_standalone.py
+++ b/tests/test_filter_standalone.py
@@ -127,8 +127,10 @@ def test_infer_does_not_register_numpyro_sites():
 def test_condition_no_observations():
     """dsx.condition with no obs returns ConditionedResult with marginal_loglik=None."""
     dynamics = _make_lti_dynamics(0.5)
+    obs_times, obs_values = _make_data()
 
     with Filter(filter_config=KFConfig(filter_source="cuthbert")):
+        dsx.condition("observed", dynamics, obs_times=obs_times, obs_values=obs_values)
         result = dsx.condition(
             "f",
             dynamics,

--- a/tests/test_filter_standalone.py
+++ b/tests/test_filter_standalone.py
@@ -130,6 +130,7 @@ def test_condition_no_observations():
     obs_times, obs_values = _make_data()
 
     with Filter(filter_config=KFConfig(filter_source="cuthbert")):
+        # Reusing the handler must not leak the first call's cached likelihood.
         dsx.condition("observed", dynamics, obs_times=obs_times, obs_values=obs_values)
         result = dsx.condition(
             "f",

--- a/tests/test_filter_standalone.py
+++ b/tests/test_filter_standalone.py
@@ -60,6 +60,32 @@ def test_infer_returns_infer_result():
     assert result.dists is not None
 
 
+def test_plated_condition_returns_backend_filter_states():
+    obs_times, obs_values = _make_data()
+    dynamics = _make_lti_dynamics(0.5)
+
+    with Filter(filter_config=KFConfig(filter_source="cuthbert")):
+        unplated_result = dsx.condition(
+            "unplated",
+            dynamics,
+            obs_times=obs_times,
+            obs_values=obs_values,
+        )
+
+    with Filter(filter_config=KFConfig(filter_source="cuthbert")):
+        with dsx.plate("members", 2):
+            result = dsx.condition(
+                "f",
+                dynamics,
+                obs_times=obs_times,
+                obs_values=jnp.stack([obs_values, obs_values]),
+            )
+
+    assert result.marginal_loglik.shape == (2,)
+    assert type(result.states) is type(unplated_result.states)
+    assert getattr(result.states, "mean").shape[:2] == (2, len(obs_times))
+
+
 def test_infer_enkf_with_crn_seed():
     """dsx.condition works with EnKF and explicit crn_seed."""
     obs_times, obs_values = _make_data()

--- a/tests/test_latent_path_builder.py
+++ b/tests/test_latent_path_builder.py
@@ -133,6 +133,7 @@ def test_stack_optional_member_values_broadcasts_members():
     actual = _stack_optional_member_values(
         [jnp.array([0.1, 0.2]), jnp.array([0.3])], (2,)
     )
+    assert actual is not None
     assert jnp.array_equal(actual, jnp.array([[0.1, 0.2], [0.3, 0.3]]))
 
 

--- a/tests/test_latent_path_builder.py
+++ b/tests/test_latent_path_builder.py
@@ -17,7 +17,10 @@ import dynestyx as dsx
 from dynestyx.inference.utils.distribution_utils import (
     _ForwardSimulationImproperUniform,
 )
-from dynestyx.inference.utils.plate_utils import _stack_optional_member_values
+from dynestyx.inference.utils.plate_utils import (
+    _stack_optional_member_values,
+    _stack_or_list_optional_member_values,
+)
 from dynestyx.observation_missingness import prepare_missing_observation_metadata
 
 
@@ -136,6 +139,17 @@ def test_stack_optional_member_values_broadcasts_members():
     )
     assert actual is not None
     assert jnp.array_equal(actual, jnp.array([[0.1, 0.2], [0.3, 0.3]]))
+
+
+def test_stack_or_list_optional_member_values_preserves_ragged_shapes():
+    actual = _stack_or_list_optional_member_values(
+        [jnp.array([0.1, 0.2]), jnp.array([0.3])],
+        (2,),
+    )
+    assert isinstance(actual, list)
+    assert len(actual) == 2
+    assert jnp.array_equal(actual[0], jnp.array([0.1, 0.2]))
+    assert jnp.array_equal(actual[1], jnp.array([0.3]))
 
 
 def test_latent_path_builder_sample_discrete_matches_log_prob():
@@ -862,6 +876,53 @@ def test_latent_path_builder_dirac_partial_missing_predictive_uses_current_layou
     )
 
 
+def test_latent_path_builder_ragged_plate_metadata_is_not_broadcast():
+    dynamics = _make_dirac_discrete_dynamics()
+    obs_times = jnp.array([0.0, 1.0])
+    obs_values = jnp.array(
+        [
+            [[0.0, jnp.nan], [jnp.nan, 1.0]],
+            [[0.0, jnp.nan], [1.0, 2.0]],
+        ]
+    )
+
+    with trace() as tr, seed(rng_seed=jr.PRNGKey(0)):
+        with dsx.LatentPathBuilder():
+            with dsx.plate("members", 2):
+                result = dsx.sample(
+                    "f",
+                    dynamics,
+                    obs_times=obs_times,
+                    obs_values=obs_values,
+                )
+
+    assert isinstance(result.state_path_params, list)
+    assert isinstance(result.state_path_param_times, list)
+    assert isinstance(result.state_path_param_coordinate_indices, list)
+    assert [value.shape for value in result.state_path_params] == [(2,), (1,)]
+    assert jnp.array_equal(
+        result.state_path_param_times[0],
+        jnp.array([0.0, 1.0]),
+    )
+    assert jnp.array_equal(
+        result.state_path_param_times[1],
+        jnp.array([0.0]),
+    )
+    assert jnp.array_equal(
+        result.state_path_param_coordinate_indices[0],
+        jnp.array([1, 0]),
+    )
+    assert jnp.array_equal(
+        result.state_path_param_coordinate_indices[1],
+        jnp.array([1]),
+    )
+    assert result.state_path.shape == (2, 2, 2)
+    assert result.state_path_times.shape == (2, 2)
+    assert result.joint_log_prob.shape == (2,)
+    assert tr["f_p0_state_path_params"]["value"].shape == (2,)
+    assert tr["f_p1_state_path_params"]["value"].shape == (1,)
+
+
 def test_latent_path_builder_dirac_partial_missing_explicit_augment_uses_state_path_params():
     dynamics = _make_dirac_discrete_dynamics()
     obs_times = jnp.array([0.0, 1.0, 2.0])
@@ -1099,6 +1160,48 @@ def test_latent_path_builder_auto_augments_student_t_partial_missing_mcmc_smoke(
         posterior["f_missing_obs_coordinate_indices"][0],
         jnp.array([0, 1], dtype=jnp.int32),
     )
+
+
+def test_latent_path_builder_ragged_augmentation_mcmc_returns_member_sites():
+    obs_times = jnp.array([0.0, 1.0])
+    obs_values = jnp.array(
+        [
+            [[0.0, jnp.nan], [jnp.nan, 1.0]],
+            [[0.0, jnp.nan], [jnp.nan, jnp.nan]],
+        ]
+    )
+    builder = dsx.LatentPathBuilder(missing_observation_strategy="augment")
+
+    def conditioned_model(obs_times=None, obs_values=None):
+        alpha = numpyro.sample("alpha", dist.Uniform(0.0, 0.9))
+        dynamics = _make_student_t_discrete_dynamics(alpha=alpha)
+
+        with builder:
+            with dsx.plate("members", 2):
+                dsx.sample(
+                    "f",
+                    dynamics,
+                    obs_times=obs_times,
+                    obs_values=obs_values,
+                )
+
+    mcmc = MCMC(
+        NUTS(conditioned_model),
+        num_warmup=2,
+        num_samples=3,
+        progress_bar=False,
+    )
+    mcmc.run(
+        jr.PRNGKey(0),
+        obs_times=obs_times,
+        obs_values=obs_values,
+    )
+
+    samples = mcmc.get_samples()
+
+    assert samples["alpha"].shape == (3,)
+    assert samples["f_p0_missing_obs_values"].shape == (3, 2)
+    assert samples["f_p1_missing_obs_values"].shape == (3, 3)
 
 
 def test_latent_path_builder_rejects_native_sdes():

--- a/tests/test_latent_path_builder.py
+++ b/tests/test_latent_path_builder.py
@@ -16,6 +16,7 @@ import dynestyx as dsx
 from dynestyx.inference.utils.distribution_utils import (
     _ForwardSimulationImproperUniform,
 )
+from dynestyx.inference.utils.plate_utils import _stack_optional_member_values
 from dynestyx.observation_missingness import prepare_missing_observation_metadata
 
 
@@ -126,6 +127,13 @@ def _manual_discrete_state_log_prob(dynamics, state_path, state_path_times):
             state_path_times[idx + 1],
         ).log_prob(state_path[idx + 1])
     return expected
+
+
+def test_stack_optional_member_values_broadcasts_members():
+    actual = _stack_optional_member_values(
+        [jnp.array([0.1, 0.2]), jnp.array([0.3])], (2,)
+    )
+    assert jnp.array_equal(actual, jnp.array([[0.1, 0.2], [0.3, 0.3]]))
 
 
 def test_latent_path_builder_sample_discrete_matches_log_prob():

--- a/tests/test_latent_path_builder.py
+++ b/tests/test_latent_path_builder.py
@@ -545,7 +545,7 @@ def test_latent_path_builder_bare_predictive_draws_dynamical_prior_paths():
     def model():
         with dsx.LatentPathBuilder():
             dsx.sample(
-                "f",
+                "bare_predictive",
                 dynamics,
                 obs_times=obs_times,
                 obs_values=obs_values,
@@ -554,8 +554,8 @@ def test_latent_path_builder_bare_predictive_draws_dynamical_prior_paths():
     predictive = Predictive(model, num_samples=3)(jr.PRNGKey(13))
 
     expected = jnp.broadcast_to(jnp.array([3.0, 5.0, 7.0]), (3, 3))
-    assert jnp.array_equal(predictive["f_state_path_params"], expected)
-    assert jnp.array_equal(predictive["f_state_path"], expected)
+    assert jnp.array_equal(predictive["bare_predictive_state_path_params"], expected)
+    assert jnp.array_equal(predictive["bare_predictive_state_path"], expected)
 
 
 def test_latent_path_builder_ode_prior_site_samples_initial_condition():
@@ -690,7 +690,7 @@ def test_latent_path_builder_dirac_partial_missing_mcmc_smoke():
     assert posterior["f_state_path"].shape == (10, 3, 2)
 
 
-def test_latent_path_builder_dirac_partial_missing_predictive_keeps_compressed_layout():
+def test_latent_path_builder_dirac_partial_missing_predictive_uses_current_layout():
     dynamics = _make_dirac_discrete_dynamics()
     obs_times = jnp.array([0.0, 1.0, 2.0])
     obs_values = jnp.array(
@@ -704,7 +704,7 @@ def test_latent_path_builder_dirac_partial_missing_predictive_keeps_compressed_l
     def conditioned_model(obs_times=None, obs_values=None):
         with dsx.LatentPathBuilder():
             dsx.sample(
-                "f",
+                "dirac_predictive",
                 dynamics,
                 obs_times=obs_times,
                 obs_values=obs_values,
@@ -713,22 +713,34 @@ def test_latent_path_builder_dirac_partial_missing_predictive_keeps_compressed_l
     with trace() as tr, seed(rng_seed=jr.PRNGKey(0)):
         conditioned_model(obs_times=obs_times, obs_values=obs_values)
 
-    assert tr["f_state_path_params"]["value"].shape == (4,)
+    assert tr["dirac_predictive_state_path_params"]["value"].shape == (4,)
     assert jnp.array_equal(
-        tr["f_state_path_param_coordinate_indices"]["value"],
+        tr["dirac_predictive_state_path_param_coordinate_indices"]["value"],
         jnp.array([1, 0, 0, 1], dtype=jnp.int32),
     )
 
+    replay_times = jnp.array([10.0, 11.0, 12.0])
+    replay_values = jnp.array(
+        [
+            [jnp.nan, 0.2],
+            [0.3, jnp.nan],
+            [jnp.nan, jnp.nan],
+        ]
+    )
     predictive = Predictive(conditioned_model, num_samples=2)(
         jr.PRNGKey(1),
-        obs_times=obs_times,
-        obs_values=obs_values,
+        obs_times=replay_times,
+        obs_values=replay_values,
     )
 
-    assert predictive["f_state_path_params"].shape == (2, 4)
+    assert predictive["dirac_predictive_state_path_params"].shape == (2, 4)
     assert jnp.array_equal(
-        predictive["f_state_path_param_coordinate_indices"][0],
-        jnp.array([1, 0, 0, 1], dtype=jnp.int32),
+        predictive["dirac_predictive_state_path_param_times"][0],
+        jnp.array([10.0, 11.0, 12.0, 12.0]),
+    )
+    assert jnp.array_equal(
+        predictive["dirac_predictive_state_path_param_coordinate_indices"][0],
+        jnp.array([0, 1, 0, 1], dtype=jnp.int32),
     )
 
 

--- a/tests/test_latent_path_builder.py
+++ b/tests/test_latent_path_builder.py
@@ -3,6 +3,7 @@
 from typing import cast
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpyro
@@ -402,6 +403,122 @@ def test_prepare_missing_observation_metadata_matches_dirac_partial_missing_layo
     )
     assert jnp.array_equal(metadata.missing_flat_indices, jnp.array([1, 2, 4, 5]))
     assert metadata.observation_shape == (3, 2)
+
+
+def test_latent_path_builder_outer_jit_predictive_refreshes_handler_metadata():
+    dynamics = _make_dirac_discrete_dynamics()
+    template_values = jnp.array([[0.2, jnp.nan], [jnp.nan, -0.1], [jnp.nan, jnp.nan]])
+    builder = dsx.LatentPathBuilder()
+
+    def model(obs_times=None, obs_values=None, predict_times=None):
+        with dsx.DiscreteTimeSimulator():
+            with builder:
+                dsx.sample(
+                    "f",
+                    dynamics,
+                    obs_times=obs_times,
+                    obs_values=obs_values,
+                    predict_times=predict_times,
+                )
+
+    Predictive(model, num_samples=1)(
+        jr.PRNGKey(0),
+        obs_times=jnp.arange(3.0),
+        obs_values=template_values,
+        predict_times=jnp.array([3.0]),
+    )
+    refreshed_values = template_values.at[0, 1].set(0.3)
+    Predictive(model, num_samples=1)(
+        jr.PRNGKey(1),
+        obs_times=jnp.arange(3.0),
+        obs_values=refreshed_values,
+        predict_times=jnp.array([3.0]),
+    )
+    predictive = jax.jit(Predictive(model, num_samples=2, exclude_deterministic=False))
+    samples = predictive(
+        jr.PRNGKey(0),
+        obs_times=jnp.array([10.0, 11.0, 12.0]),
+        obs_values=jnp.array([[0.4, 0.5], [jnp.nan, 0.7], [jnp.nan, jnp.nan]]),
+        predict_times=jnp.array([13.0, 14.0]),
+    )
+
+    assert jnp.array_equal(
+        samples["f_state_path_param_times"][0],
+        jnp.array([11.0, 12.0, 12.0]),
+    )
+    with pytest.raises(
+        jax.errors.JaxRuntimeError,
+        match="does not match the LatentPathBuilder layout",
+    ):
+        jax.block_until_ready(
+            predictive(
+                jr.PRNGKey(1),
+                obs_times=jnp.arange(3.0),
+                obs_values=template_values,
+                predict_times=jnp.array([3.0]),
+            )["f_state_path"]
+        )
+
+
+def test_latent_path_builder_outer_jit_predictive_accepts_explicit_metadata():
+    dynamics = _make_dirac_discrete_dynamics()
+    obs_values = jnp.array([[0.0, jnp.nan], [jnp.nan, 1.0]])
+    metadata = dsx.prepare_missing_observation_metadata(
+        dynamics,
+        obs_times=jnp.arange(2.0),
+        obs_values=obs_values,
+    )
+
+    def model(obs_times=None, obs_values=None, predict_times=None):
+        with dsx.DiscreteTimeSimulator(), dsx.LatentPathBuilder():
+            dsx.sample(
+                "f",
+                dynamics,
+                obs_times=obs_times,
+                obs_values=obs_values,
+                predict_times=predict_times,
+                missing_obs_metadata=metadata,
+            )
+
+    samples = jax.jit(Predictive(model, num_samples=1, exclude_deterministic=False))(
+        jr.PRNGKey(0),
+        obs_times=jnp.array([10.0, 11.0]),
+        obs_values=obs_values,
+        predict_times=jnp.array([12.0]),
+    )
+
+    assert jnp.array_equal(
+        samples["f_state_path_param_times"][0],
+        jnp.array([10.0, 11.0]),
+    )
+    assert jnp.array_equal(
+        samples["f_state_path_param_coordinate_indices"][0],
+        jnp.array([1, 0]),
+    )
+
+
+def test_latent_path_builder_outer_jit_predictive_requires_a_layout():
+    dynamics = _make_dirac_discrete_dynamics()
+    builder = dsx.LatentPathBuilder()
+
+    def model(obs_times=None, obs_values=None):
+        with builder:
+            dsx.sample(
+                "f",
+                dynamics,
+                obs_times=obs_times,
+                obs_values=obs_values,
+            )
+
+    with pytest.raises(
+        ValueError,
+        match="traced obs_values.*concrete observations.*missing_obs_metadata",
+    ):
+        jax.jit(Predictive(model, num_samples=1))(
+            jr.PRNGKey(0),
+            obs_times=jnp.arange(2.0),
+            obs_values=jnp.array([[0.0, jnp.nan], [jnp.nan, 1.0]]),
+        )
 
 
 def test_latent_path_builder_rejects_dsx_condition():

--- a/tests/test_log_prob_standalone.py
+++ b/tests/test_log_prob_standalone.py
@@ -86,6 +86,31 @@ def test_log_prob_discrete_matches_manual_joint_density():
     )
 
 
+def test_log_prob_preserves_distribution_batch_axes():
+    times = jnp.array([0.0, 1.0])
+    state_path = jnp.array([[0.2, -0.1], [0.4, 0.3]])
+    offsets = jnp.array([0.0, 1.0])
+    dynamics = dsx.DynamicalModel(
+        control_dim=0,
+        initial_condition=dist.Normal(offsets, 1.0),
+        state_evolution=lambda x, u, t_now, t_next: dist.Normal(x + offsets, 1.0),
+        observation_model=lambda x, u, t: dist.Normal(x, 1.0),
+    )
+
+    actual = dsx.log_prob(
+        dynamics,
+        state_path_params=state_path,
+        state_path_param_times=times,
+    )
+    expected = dynamics.initial_condition.log_prob(state_path[0])
+    expected += dynamics.state_evolution(
+        state_path[0], None, times[0], times[1]
+    ).log_prob(state_path[1])
+
+    assert actual.shape == (2,)
+    assert jnp.allclose(actual, expected)
+
+
 def test_log_prob_discrete_missingness_matches_manual_masking():
     state_times = jnp.array([0.0, 1.0])
     state_path_params = jnp.array([[0.2, -0.1], [0.4, 0.3]])

--- a/tests/test_missing_observations.py
+++ b/tests/test_missing_observations.py
@@ -1,4 +1,5 @@
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -156,6 +157,16 @@ def test_cuthbert_gaussian_discrete_time_missing_observation_support_matrix(
         with pytest.raises(_EQX_ERRORS, match=error_match):
             with context:
                 _identity_lti_model(obs_times=obs_times, obs_values=missing_obs_values)
+        with pytest.raises(Exception, match=error_match):
+            jax.block_until_ready(
+                jax.jit(
+                    lambda values: _validate_missing_observation_support(
+                        config,
+                        obs_values=values,
+                        mode=mode,
+                    )
+                )(missing_obs_values)
+            )
         return
 
     with trace() as tr:

--- a/tests/test_smoother_standalone.py
+++ b/tests/test_smoother_standalone.py
@@ -64,6 +64,32 @@ def test_infer_smoother_returns_infer_result():
     assert result.dists is not None
 
 
+def test_plated_condition_returns_backend_smoother_states():
+    obs_times, obs_values = _make_data()
+    dynamics = _make_lti_dynamics(0.5)
+
+    with Smoother(smoother_config=KFSmootherConfig(filter_source="cuthbert")):
+        unplated_result = dsx.condition(
+            "unplated",
+            dynamics,
+            obs_times=obs_times,
+            obs_values=obs_values,
+        )
+
+    with Smoother(smoother_config=KFSmootherConfig(filter_source="cuthbert")):
+        with dsx.plate("members", 2):
+            result = dsx.condition(
+                "f",
+                dynamics,
+                obs_times=obs_times,
+                obs_values=jnp.stack([obs_values, obs_values]),
+            )
+
+    assert result.marginal_loglik.shape == (2,)
+    assert type(result.states) is type(unplated_result.states)
+    assert getattr(result.states, "mean").shape[:2] == (2, len(obs_times))
+
+
 def test_infer_smoother_optax_mle():
     """Use dsx.condition + Smoother + optax to do MLE without numpyro."""
     obs_times, obs_values = _make_data()

--- a/tests/test_smoother_standalone.py
+++ b/tests/test_smoother_standalone.py
@@ -50,7 +50,11 @@ def test_infer_smoother_returns_infer_result():
 
     with Smoother(smoother_config=KFSmootherConfig(filter_source="cuthbert")):
         result = dsx.condition(
-            "f", dynamics, obs_times=obs_times, obs_values=obs_values
+            "f",
+            dynamics,
+            obs_times=obs_times,
+            obs_values=obs_values,
+            predict_times=jnp.arange(obs_times[-1], obs_times[-1] + 3.0),
         )
 
     assert isinstance(result, ConditionedResult)

--- a/tests/test_smoother_standalone.py
+++ b/tests/test_smoother_standalone.py
@@ -110,8 +110,10 @@ def test_infer_smoother_does_not_register_numpyro_sites():
 def test_condition_smoother_no_observations():
     """dsx.condition with Smoother and no obs returns ConditionedResult with marginal_loglik=None."""
     dynamics = _make_lti_dynamics(0.5)
+    obs_times, obs_values = _make_data()
 
     with Smoother(smoother_config=KFSmootherConfig(filter_source="cuthbert")):
+        dsx.condition("observed", dynamics, obs_times=obs_times, obs_values=obs_values)
         result = dsx.condition(
             "f",
             dynamics,

--- a/tests/test_smoother_standalone.py
+++ b/tests/test_smoother_standalone.py
@@ -117,6 +117,7 @@ def test_condition_smoother_no_observations():
     obs_times, obs_values = _make_data()
 
     with Smoother(smoother_config=KFSmootherConfig(filter_source="cuthbert")):
+        # Reusing the handler must not leak the first call's cached likelihood.
         dsx.condition("observed", dynamics, obs_times=obs_times, obs_values=obs_values)
         result = dsx.condition(
             "f",


### PR DESCRIPTION
Found some bugs from a Codex pass over #255.

- [Fix the filter configuration documentation link (was still linked to the old version).](https://github.com/BasisResearch/dynestyx/commit/7b5eac50a7fa20e12b5d74a3c7eabfedc3260c70)
- [Preserve smoother distributions during posterior rollout (posterior rollout previously deleted some information from metadata).](https://github.com/BasisResearch/dynestyx/commit/6b452823e1a018925adb58e144665fd6c0816b53)
- [Defer batched HMM site registration until sampling (HMMs retained some numpyro deterministic calls in condition).](https://github.com/BasisResearch/dynestyx/commit/1abb541735b6a1ad2433e8e56e7e3caf6be638da)
- [Clear cached filter and smoother state before each call (make sure attributed like log likeihood are reset each `dsx.sample` call with the same handler object).](https://github.com/BasisResearch/dynestyx/commit/72b7118ac9ca9348b92ba0f93f545799059e5e1a)
- [Broadcast compatible plate-member values before stacking (broadcast all plated objects before stacking them; necessary if there are different plating levels used).](https://github.com/BasisResearch/dynestyx/commit/9fdec59f252a19865d790cb5879775a98e6569ec)
- [Preserve distribution batch axes when summing path log probabilities (makes sure to preserve summing over time axis only).](https://github.com/BasisResearch/dynestyx/commit/0239323722c7a9fe47b3696ca2c44ae995422a33)
- [Keep Equinox runtime guards live under JIT (how we were using `eqx.error_if` didn't actually produce errors when jitted).](https://github.com/BasisResearch/dynestyx/commit/f86b98869eae614cfd0262c2f3b7a2b83f886609)
- [Remove global missingness metadata caching (use compile-time metadata resolution instead of caching mechanism).](https://github.com/BasisResearch/dynestyx/commit/d1a9b4d2e2fb9dc7695c02b4b36f1cfe3dd8682f)