### PR TITLE
Update effectful version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "effectful>=0.2.0",
+    "effectful>=0.4.0",
     "cuthbert>=0.0.10",
     "cuthbertlib>=0.0.10",
     "cd-dynamax>=0.3.3",


### PR DESCRIPTION
Previously, errors would occur if `effectful.handlers.numpyro` was imported anywhere. This was patched in v0.0.4 of effectful, which is now marked as required. Concretely, the following code would crash before, but has the expected behavior now:

```python
import effectful.handlers.numpyro 
import jax.numpy as jnp
import jax
import numpyro
import dynestyx as dsx


dynamics = dsx.LTI_discrete(
    A=jnp.eye(1),
    Q=jnp.eye(1),
    H=jnp.eye(1),
    R=jnp.eye(1),
    initial_mean=jnp.zeros(1),
    initial_cov=jnp.eye(1),
)
with numpyro.handlers.seed(rng_seed=0), dsx.Simulator():
    dsx.sample("f", dynamics, predict_times=jnp.arange(2.0))
```

Thanks @cooijmanstim for finding the bug and @jfeser for making a quick fix.