### PR TITLE
Support for sparse observation matrices

### DIFF
--- a/dynestyx/handlers.py
+++ b/dynestyx/handlers.py
@@ -6,10 +6,12 @@ import numpyro
 from effectful.ops.semantics import fwd, handler
 from effectful.ops.syntax import ObjectInterpretation, defop, implements
 from effectful.ops.types import NotHandled
+from jax.experimental import sparse as jax_sparse
 from jaxtyping import Array, Bool, Real
 
 from dynestyx.models import (
     DynamicalModel,
+    LinearGaussianObservation,
 )
 from dynestyx.observation_missingness import (
     prepare_observation_views,
@@ -481,5 +483,15 @@ class plate(ObjectInterpretation):
             simulators/filters or ``LatentStateResult`` for
             ``LatentPathBuilder``.
         """
+        obs_model = dynamics.observation_model
+        if isinstance(obs_model, LinearGaussianObservation) and isinstance(
+            obs_model.H, jax_sparse.JAXSparse
+        ):
+            raise ValueError(
+                "Sparse observation matrices are not currently supported inside "
+                "dsx.plate. Convert H to a dense array before using this model in "
+                "a plate."
+            )
+
         # Append plate_shapes metadata to the argument stack and pass forward.
         return fwd(name, dynamics, plate_shapes=plate_shapes + (self.size,), **kwargs)

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -11,7 +11,6 @@ import numpyro
 from cd_dynamax import ContDiscreteNonlinearGaussianSSM, ContDiscreteNonlinearSSM
 from effectful.ops.semantics import fwd
 from effectful.ops.syntax import ObjectInterpretation, implements
-from jax.experimental import sparse as jax_sparse
 from jaxtyping import Array, Bool, PRNGKeyArray, Real
 
 from dynestyx.handlers import HandlesSelf, _condition_intp
@@ -71,7 +70,6 @@ from dynestyx.inference.utils.plate_utils import (
     _slice_dist_for_plate_member,
 )
 from dynestyx.models import DynamicalModel
-from dynestyx.models.observations import LinearGaussianObservation
 from dynestyx.types import (
     ConditionedResult,
     FunctionOfTime,
@@ -279,25 +277,6 @@ class Filter(BaseLogFactorAdder):
                 mode="filter",
             )
 
-        obs_model = dynamics.observation_model
-        # Sparse observation matrices: incompatible with KF, compatible with EKF (but most likely inefficient)
-        if isinstance(obs_model, LinearGaussianObservation) and isinstance(
-            obs_model.H, jax_sparse.JAXSparse
-        ):
-            if isinstance(config, KFConfig):
-                raise ValueError(
-                    "A sparse observation matrix H was passed to KFConfig. This is not "
-                    "supported: the underlying cuthbert Kalman-filter internals cannot "
-                    "handle a sparse H. Pass a dense H, or use EnKFConfig/EKFConfig instead."
-                )
-            if isinstance(config, EKFConfig):
-                warnings.warn(
-                    "A sparse observation matrix H was passed to EKFConfig. This works "
-                    "correctly, but likely gives no efficiency gain as EKF differentiates the observation log-density instead, which"
-                    "scales with the dense state/observation dimensions "
-                    "regardless of H's sparsity.",
-                    stacklevel=2,
-                )
         # Resolve PRNG key: use explicit seed from config, fall back to numpyro
         # context (inside a seeded model), or None (deterministic filters don't need one).
         if config.crn_seed is not None:

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -1,5 +1,6 @@
 import dataclasses
 import math
+import warnings
 from abc import ABC, abstractmethod
 from typing import cast
 
@@ -10,6 +11,7 @@ import numpyro
 from cd_dynamax import ContDiscreteNonlinearGaussianSSM, ContDiscreteNonlinearSSM
 from effectful.ops.semantics import fwd
 from effectful.ops.syntax import ObjectInterpretation, implements
+from jax.experimental import sparse as jax_sparse
 from jaxtyping import Array, Bool, PRNGKeyArray, Real
 
 from dynestyx.handlers import HandlesSelf, _condition_intp
@@ -69,6 +71,7 @@ from dynestyx.inference.utils.plate_utils import (
     _slice_dist_for_plate_member,
 )
 from dynestyx.models import DynamicalModel
+from dynestyx.models.observations import LinearGaussianObservation
 from dynestyx.types import (
     ConditionedResult,
     FunctionOfTime,
@@ -167,6 +170,8 @@ def _default_filter_config(dynamics: DynamicalModel) -> BaseFilterConfig:
         return ContinuousTimeEnKFConfig()
 
     return EnKFConfig()
+
+
 
 
 @dataclasses.dataclass
@@ -276,13 +281,25 @@ class Filter(BaseLogFactorAdder):
                 mode="filter",
             )
 
+        obs_model = dynamics.observation_model
+        # Add a simple warning for sparse observation matrices + EKF/KF filters
+        if (
+            isinstance(obs_model, LinearGaussianObservation)
+            and isinstance(obs_model.H, jax_sparse.JAXSparse)
+            and isinstance(config, (KFConfig, EKFConfig))
+        ):
+            warnings.warn(
+                f"A sparse observation matrix H was passed to {type(config).__name__}. "
+                "This is unlikely to be supported: the underlying cuthbert Kalman-filter "
+                "internals assume dense arrays. If sparse H support is ever added for "
+                "KF/EKF, this warning can be removed.",
+                stacklevel=2,
+            )
         # Resolve PRNG key: use explicit seed from config, fall back to numpyro
         # context (inside a seeded model), or None (deterministic filters don't need one).
         if config.crn_seed is not None:
             key = config.crn_seed
         else:
-            import warnings  # noqa: PLC0415
-
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 key = numpyro.prng_key()  # returns None outside seed handler

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -293,7 +293,7 @@ class Filter(BaseLogFactorAdder):
             if isinstance(config, EKFConfig):
                 warnings.warn(
                     "A sparse observation matrix H was passed to EKFConfig. This works "
-                    "correctly, but likely gives no efficiency gain as EKF differentiates the observation log-density instead, which" \
+                    "correctly, but likely gives no efficiency gain as EKF differentiates the observation log-density instead, which"
                     "scales with the dense state/observation dimensions "
                     "regardless of H's sparsity.",
                     stacklevel=2,

--- a/dynestyx/inference/filters.py
+++ b/dynestyx/inference/filters.py
@@ -172,8 +172,6 @@ def _default_filter_config(dynamics: DynamicalModel) -> BaseFilterConfig:
     return EnKFConfig()
 
 
-
-
 @dataclasses.dataclass
 class Filter(BaseLogFactorAdder):
     r"""Performs Bayesian filtering to compute the filtering distribution $p(x_t | y_{1:t})$ and the marginal likelihood $\log p(y_{1:T})$.
@@ -282,19 +280,24 @@ class Filter(BaseLogFactorAdder):
             )
 
         obs_model = dynamics.observation_model
-        # Add a simple warning for sparse observation matrices + EKF/KF filters
-        if (
-            isinstance(obs_model, LinearGaussianObservation)
-            and isinstance(obs_model.H, jax_sparse.JAXSparse)
-            and isinstance(config, (KFConfig, EKFConfig))
+        # Sparse observation matrices: incompatible with KF, compatible with EKF (but most likely inefficient)
+        if isinstance(obs_model, LinearGaussianObservation) and isinstance(
+            obs_model.H, jax_sparse.JAXSparse
         ):
-            warnings.warn(
-                f"A sparse observation matrix H was passed to {type(config).__name__}. "
-                "This is unlikely to be supported: the underlying cuthbert Kalman-filter "
-                "internals assume dense arrays. If sparse H support is ever added for "
-                "KF/EKF, this warning can be removed.",
-                stacklevel=2,
-            )
+            if isinstance(config, KFConfig):
+                raise ValueError(
+                    "A sparse observation matrix H was passed to KFConfig. This is not "
+                    "supported: the underlying cuthbert Kalman-filter internals cannot "
+                    "handle a sparse H. Pass a dense H, or use EnKFConfig/EKFConfig instead."
+                )
+            if isinstance(config, EKFConfig):
+                warnings.warn(
+                    "A sparse observation matrix H was passed to EKFConfig. This works "
+                    "correctly, but likely gives no efficiency gain as EKF differentiates the observation log-density instead, which" \
+                    "scales with the dense state/observation dimensions "
+                    "regardless of H's sparsity.",
+                    stacklevel=2,
+                )
         # Resolve PRNG key: use explicit seed from config, fall back to numpyro
         # context (inside a seeded model), or None (deterministic filters don't need one).
         if config.crn_seed is not None:

--- a/dynestyx/inference/integrations/cd_dynamax/discrete_filter.py
+++ b/dynestyx/inference/integrations/cd_dynamax/discrete_filter.py
@@ -1,5 +1,6 @@
 """Discrete-time filters via cd-dynamax (dynamax): KF, EKF, UKF."""
 
+import warnings
 from typing import Any, cast
 
 import jax.numpy as jnp
@@ -15,6 +16,7 @@ from cd_dynamax.dynamax.nonlinear_gaussian_ssm.inference_ukf import (
     UKFHyperParams,
     unscented_kalman_filter,
 )
+from jax.experimental import sparse as jax_sparse
 from jaxtyping import Array, Real
 
 from dynestyx.inference.configs.filter import (
@@ -132,6 +134,16 @@ def compute_cd_dynamax_discrete_filter(
     params_nl = gaussian_to_nlgssm_params(dynamics)
 
     if isinstance(filter_config, EKFConfig):
+        obs_model = dynamics.observation_model
+        if isinstance(obs_model, LinearGaussianObservation) and isinstance(
+            obs_model.H, jax_sparse.JAXSparse
+        ):
+            warnings.warn(
+                "A sparse observation matrix H was passed to EKFConfig. This works "
+                  "correctly, but likely gives no efficiency gain due to internal"
+                  "use of automatic differentiation.",
+                stacklevel=2,
+            )
         return extended_kalman_filter(params_nl, emissions, inputs=inputs)
     if isinstance(filter_config, UKFConfig):
         hyperparams = UKFHyperParams(

--- a/dynestyx/inference/integrations/cd_dynamax/discrete_filter.py
+++ b/dynestyx/inference/integrations/cd_dynamax/discrete_filter.py
@@ -140,8 +140,8 @@ def compute_cd_dynamax_discrete_filter(
         ):
             warnings.warn(
                 "A sparse observation matrix H was passed to EKFConfig. This works "
-                  "correctly, but likely gives no efficiency gain due to internal"
-                  "use of automatic differentiation.",
+                "correctly, but likely gives no efficiency gain due to internal"
+                "use of automatic differentiation.",
                 stacklevel=2,
             )
         return extended_kalman_filter(params_nl, emissions, inputs=inputs)

--- a/dynestyx/inference/integrations/cuthbert/discrete_filter.py
+++ b/dynestyx/inference/integrations/cuthbert/discrete_filter.py
@@ -419,11 +419,7 @@ def _cuthbert_filter_enkf(dynamics: DynamicalModel, filter_kwargs: dict | None =
         if isinstance(obs_model, LinearGaussianObservation):
             obs_params = obs_model.params_at(mi.time)
 
-            # Handle sparse observation matrix
-            if isinstance(obs_params.H, jax_sparse.JAXSparse):
-                H = obs_params.H
-            else:
-                H = jnp.asarray(obs_params.H)
+            H = obs_params.H
 
             chol_R = jnp.linalg.cholesky(jnp.atleast_2d(jnp.asarray(obs_params.R)))
             bias = (
@@ -597,6 +593,15 @@ def _cuthbert_filter_kalman(
     obs = dynamics.observation_model
     ic = dynamics.initial_condition
 
+    if isinstance(obs.H, jax_sparse.JAXSparse):
+        raise ValueError(
+            "A sparse observation matrix H was passed to KFConfig(filter_source="
+            "'cuthbert'). This is not supported with  filter_source = 'cuthbert' due "
+            "to internal incompatibilities. Either pass a dense H, use KFConfig(filter_source="
+            "'cd_dynamax') (works, verified bit-identical to dense), or use another config such as"
+            "EnKFConfig/EKFConfig."
+        )
+
     state_dim = dynamics.state_dim
     obs_dim = dynamics.observation_dim
 
@@ -627,6 +632,17 @@ def _cuthbert_filter_taylor_kf(
 ):
     if filter_kwargs is None:
         filter_kwargs = {}
+
+    obs_model = dynamics.observation_model
+    if isinstance(obs_model, LinearGaussianObservation) and isinstance(
+        obs_model.H, jax_sparse.JAXSparse
+    ):
+        warnings.warn(
+            "A sparse observation matrix H was passed to EKFConfig. This works "
+            "correctly, but likely gives no efficiency gain due to internal"
+            "use of automatic differentiation.",
+            stacklevel=2,
+        )
 
     rtol = filter_kwargs.get("rtol", None)
 

--- a/dynestyx/inference/integrations/cuthbert/discrete_filter.py
+++ b/dynestyx/inference/integrations/cuthbert/discrete_filter.py
@@ -14,6 +14,7 @@ from cuthbertlib.resampling import (
     stop_gradient_decorator,
     systematic,
 )
+from jax.experimental import sparse as jax_sparse
 from jaxtyping import Array, Bool, Float, PRNGKeyArray, Real
 
 from dynestyx.inference.configs.filter import (
@@ -405,7 +406,14 @@ def _cuthbert_filter_enkf(dynamics: DynamicalModel, filter_kwargs: dict | None =
 
         if isinstance(obs_model, LinearGaussianObservation):
             obs_params = obs_model.params_at(mi.time)
-            H = jnp.asarray(obs_params.H)
+
+            # Handle sparse observation matrix
+            if isinstance(obs_params.H, jax_sparse.JAXSparse):
+                H = obs_params.H
+            else:
+                H = jnp.asarray(obs_params.H)
+
+
             chol_R = jnp.linalg.cholesky(jnp.atleast_2d(jnp.asarray(obs_params.R)))
             bias = (
                 jnp.zeros((obs_dim,), dtype=y.dtype)

--- a/dynestyx/inference/integrations/cuthbert/discrete_filter.py
+++ b/dynestyx/inference/integrations/cuthbert/discrete_filter.py
@@ -413,7 +413,6 @@ def _cuthbert_filter_enkf(dynamics: DynamicalModel, filter_kwargs: dict | None =
             else:
                 H = jnp.asarray(obs_params.H)
 
-
             chol_R = jnp.linalg.cholesky(jnp.atleast_2d(jnp.asarray(obs_params.R)))
             bias = (
                 jnp.zeros((obs_dim,), dtype=y.dtype)

--- a/dynestyx/inference/integrations/cuthbert/discrete_filter.py
+++ b/dynestyx/inference/integrations/cuthbert/discrete_filter.py
@@ -379,7 +379,7 @@ def _cuthbert_filter_enkf(dynamics: DynamicalModel, filter_kwargs: dict | None =
     obs_dim = dynamics.observation_dim
 
     obs_model = dynamics.observation_model
-    if not isinstance(obs_model, (LinearGaussianObservation, GaussianObservation)):
+    if not isinstance(obs_model, LinearGaussianObservation | GaussianObservation):
         _probe_state_independent_observation_noise(
             obs_model, state_dim=state_dim, obs_dim=obs_dim
         )
@@ -447,7 +447,7 @@ def _cuthbert_filter_enkf(dynamics: DynamicalModel, filter_kwargs: dict | None =
             def observation_fn(x):
                 edist = obs_model(x, mi.u, mi.time)
                 if not (
-                    isinstance(edist, (dist.MultivariateNormal, dist.Normal))
+                    isinstance(edist, dist.MultivariateNormal | dist.Normal)
                     or (
                         isinstance(edist, dist.Independent)
                         and isinstance(edist.base_dist, dist.Normal)

--- a/dynestyx/models/observations.py
+++ b/dynestyx/models/observations.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from typing import NamedTuple, cast
 
 import jax.numpy as jnp
+from jax.experimental import sparse as jax_sparse
 from jaxtyping import Array, Float, Real
 from numpyro import distributions as dist
 
@@ -22,7 +23,7 @@ class LinearGaussianObservationParams(NamedTuple):
     member-sliced (reduced-rank) parameter to `__call__`.
     """
 
-    H: Float[Array, "..."]
+    H: Float[Array, "..."] | jax_sparse.JAXSparse
     D: Float[Array, "..."] | None
     bias: Float[Array, "..."] | None
     R: Float[Array, "..."]
@@ -62,6 +63,7 @@ class LinearGaussianObservation(ObservationModel):
 
     H: (
         Float[Array, "*h_plate observation_dim state_dim"]
+        | jax_sparse.JAXSparse
         | Callable[
             [float | int | Real[Array, ""]],
             Float[Array, "*h_plate observation_dim state_dim"],
@@ -94,6 +96,7 @@ class LinearGaussianObservation(ObservationModel):
     def __init__(
         self,
         H: Float[Array, "*h_plate observation_dim state_dim"]
+        | jax_sparse.JAXSparse
         | Callable[
             [float | int | Real[Array, ""]],
             Float[Array, "*h_plate observation_dim state_dim"],
@@ -118,8 +121,10 @@ class LinearGaussianObservation(ObservationModel):
     ):
         """
         Args:
-            H (jax.Array | Callable): Observation matrix with shape
-                $(d_y, d_x)$, or a callable `(t,)` returning it.
+            H (jax.Array | jax.experimental.sparse.JAXSparse | Callable): Observation
+                matrix with shape $(d_y, d_x)$, or a callable `(t,)` returning it. May be
+                a sparse (e.g. `BCOO`) array for `EnKFConfig`/`PFConfig`; not supported for
+                `KFConfig`/`EKFConfig` (warns).
             R (jax.Array | Callable): Observation noise covariance with shape
                 $(d_y, d_y)$, or a callable `(t,)` returning it.
             D (jax.Array | Callable | None): Optional control matrix with
@@ -165,9 +170,9 @@ class LinearGaussianObservation(ObservationModel):
 
     def __call__(self, x, u, t):
         H, D, bias, R = self.params_at(t)
-        loc = jnp.dot(H, x)
+        loc = H @ x
         if D is not None and u is not None:
-            loc = loc + jnp.dot(D, u)
+            loc = loc + D @ u
         if bias is not None:
             loc = loc + bias
         return dist.MultivariateNormal(loc=loc, covariance_matrix=R)

--- a/dynestyx/models/observations.py
+++ b/dynestyx/models/observations.py
@@ -123,8 +123,9 @@ class LinearGaussianObservation(ObservationModel):
         Args:
             H (jax.Array | jax.experimental.sparse.JAXSparse | Callable): Observation
                 matrix with shape $(d_y, d_x)$, or a callable `(t,)` returning it. May be
-                a sparse (e.g. `BCOO`) array for `EnKFConfig`/`PFConfig`; not supported for
-                `KFConfig`/`EKFConfig` (warns).
+                a sparse (e.g. `BCOO`) array for `EnKFConfig`/`PFConfig`/`EKFConfig`
+                (EKF works but likely gives no efficiency gain, warns); raises for
+                `KFConfig`, which cannot support a sparse `H`.
             R (jax.Array | Callable): Observation noise covariance with shape
                 $(d_y, d_y)$, or a callable `(t,)` returning it.
             D (jax.Array | Callable | None): Optional control matrix with

--- a/dynestyx/models/observations.py
+++ b/dynestyx/models/observations.py
@@ -124,8 +124,9 @@ class LinearGaussianObservation(ObservationModel):
             H (jax.Array | jax.experimental.sparse.JAXSparse | Callable): Observation
                 matrix with shape $(d_y, d_x)$, or a callable `(t,)` returning it. May be
                 a sparse (e.g. `BCOO`) array for `EnKFConfig`/`PFConfig`/`EKFConfig`
-                (EKF works but likely gives no efficiency gain, warns); raises for
-                `KFConfig`, which cannot support a sparse `H`.
+                (EKF works but likely gives no efficiency gain, warns) and for
+                `KFConfig(filter_source="cd_dynamax")`; raises for
+                `KFConfig(filter_source="cuthbert")`, which cannot support a sparse `H`.
             R (jax.Array | Callable): Observation noise covariance with shape
                 $(d_y, d_y)$, or a callable `(t,)` returning it.
             D (jax.Array | Callable | None): Optional control matrix with

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -521,7 +521,7 @@ def test_cuthbert_enkf_sparse_h_matches_dense_h():
     ground_truth = dsx.simulate(
         dynamics_dense, rng_key=jr.PRNGKey(0), predict_times=obs_times, n_simulations=1
     )
-    obs_values = ground_truth.observations[0]
+    obs_values = jnp.asarray(ground_truth.observations)[0]
 
     # Fixed crn_seed: EnKF's randomness becomes a deterministic function of its inputs, so
     # dense and sparse H should give numerically identical results, not just close ones.
@@ -569,7 +569,7 @@ def test_ekf_warns_on_sparse_observation_matrix_but_still_works():
     ground_truth = dsx.simulate(
         dynamics_dense, rng_key=jr.PRNGKey(0), predict_times=obs_times, n_simulations=1
     )
-    obs_values = ground_truth.observations[0]
+    obs_values = jnp.asarray(ground_truth.observations)[0]
 
     with Filter(filter_config=EKFConfig(filter_source="cuthbert")):
         result_dense = dsx.condition(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -508,6 +508,17 @@ def test_linear_gaussian_observation_sparse_h_matches_dense_h():
     assert jnp.allclose(obs_dense.mean, obs_sparse.mean)
 
 
+@pytest.mark.xfail(
+    raises=ValueError,
+    strict=True,
+    reason="Sparse observation matrices are not supported inside dsx.plate.",
+)
+def test_sparse_h_in_plate():
+    dynamics = _sparse_h_test_dynamics(jax_sparse.BCOO.fromdense(jnp.eye(2, 3)))
+    with dsx.plate("members", 1):
+        dsx.sample("f", dynamics, predict_times=jnp.arange(1.0))
+
+
 def test_cuthbert_enkf_sparse_h_matches_dense_h():
     """EnKF with a sparse H must give the same marginal_loglik and filtered means as the
     dense H -- exercises the `_as_array_or_sparse` fix in the cuthbert EnKF backend."""

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,6 +3,7 @@ import jax.random as jr
 import numpyro
 import numpyro.distributions as dist
 import pytest
+from jax.experimental import sparse as jax_sparse
 from numpyro.handlers import seed, trace
 from numpyro.infer import Predictive
 
@@ -22,7 +23,13 @@ from dynestyx.inference.integrations.cuthbert.discrete import (
 from dynestyx.inference.integrations.cuthbert.discrete import (
     run_discrete_filter as run_cuthbert_discrete_filter,
 )
-from dynestyx.models import ContinuousTimeStateEvolution, DynamicalModel, FullDiffusion
+from dynestyx.models import (
+    ContinuousTimeStateEvolution,
+    DynamicalModel,
+    FullDiffusion,
+    LinearGaussianStateEvolution,
+)
+from dynestyx.models.observations import LinearGaussianObservation
 from tests.fixtures import (
     _squeeze_sim_dims,
     data_conditioned_jumpy_controls,
@@ -463,3 +470,90 @@ def test_default_discrete_filter_uses_cuthbert_enkf_on_nonlinear_model():
             substituted(obs_times=obs_times, obs_values=obs_values)
 
     assert jnp.isfinite(tr["f_marginal_loglik"]["value"])
+
+
+# --- sparse H (LinearGaussianObservation) ----------------------------------
+
+
+def _sparse_h_test_dynamics(H) -> DynamicalModel:
+    """A small 3-state, LTI model observing 2 (of 3) state components via H.
+
+    Built directly from `LinearGaussianStateEvolution`/`LinearGaussianObservation` rather
+    than the `LTI_discrete` factory, since `LTI_discrete`'s own `H` parameter is typed as a
+    dense `Float[Array, ...]` and isn't part of this change's scope.
+    """
+    A = jnp.array([[0.9, 0.05, 0.0], [0.0, 0.85, 0.05], [0.0, 0.0, 0.8]])
+    Q = 0.05 * jnp.eye(3)
+    R = 0.1**2 * jnp.eye(H.shape[0])
+    return DynamicalModel(
+        initial_condition=dist.MultivariateNormal(jnp.zeros(3), jnp.eye(3)),
+        state_evolution=LinearGaussianStateEvolution(A=A, cov=Q),
+        observation_model=LinearGaussianObservation(H=H, R=R),
+        control_dim=0,
+    )
+
+
+def test_linear_gaussian_observation_sparse_h_matches_dense_h():
+    """A sparse H must give the same observation mean as its dense equivalent --
+    exercises the `H @ x` fix in LinearGaussianObservation.__call__ directly."""
+    H_dense = jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    H_sparse = jax_sparse.BCOO.fromdense(H_dense)
+    x = jnp.array([0.4, -0.2, 1.1])
+
+    obs_dense = LinearGaussianObservation(H=H_dense, R=0.01 * jnp.eye(2))(x, None, 0.0)
+    obs_sparse = LinearGaussianObservation(H=H_sparse, R=0.01 * jnp.eye(2))(
+        x, None, 0.0
+    )
+
+    assert jnp.allclose(obs_dense.mean, obs_sparse.mean)
+
+
+def test_cuthbert_enkf_sparse_h_matches_dense_h():
+    """EnKF with a sparse H must give the same marginal_loglik and filtered means as the
+    dense H -- exercises the `_as_array_or_sparse` fix in the cuthbert EnKF backend."""
+    H_dense = jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    H_sparse = jax_sparse.BCOO.fromdense(H_dense)
+
+    dynamics_dense = _sparse_h_test_dynamics(H_dense)
+    dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
+
+    obs_times = jnp.arange(6.0)
+    ground_truth = dsx.simulate(
+        dynamics_dense, rng_key=jr.PRNGKey(0), predict_times=obs_times, n_simulations=1
+    )
+    obs_values = ground_truth.observations[0]
+
+    # Fixed crn_seed: EnKF's randomness becomes a deterministic function of its inputs, so
+    # dense and sparse H should give numerically identical results, not just close ones.
+    crn_seed = jr.PRNGKey(42)
+    with Filter(filter_config=EnKFConfig(n_particles=32, crn_seed=crn_seed)):
+        result_dense = dsx.condition(
+            "f", dynamics_dense, obs_times=obs_times, obs_values=obs_values
+        )
+    with Filter(filter_config=EnKFConfig(n_particles=32, crn_seed=crn_seed)):
+        result_sparse = dsx.condition(
+            "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
+        )
+
+    assert jnp.allclose(result_dense.marginal_loglik, result_sparse.marginal_loglik)
+    means_dense = jnp.stack([d.mean for d in result_dense.dists])
+    means_sparse = jnp.stack([d.mean for d in result_sparse.dists])
+    assert jnp.allclose(means_dense, means_sparse)
+
+
+def test_kf_warns_on_sparse_observation_matrix():
+    """KF is not expected to support a sparse H: the warning should fire, and (since KF
+    itself is not fixed by this change, only EnKF is) it should still go on to fail --
+    confirming the warning is an accurate heads-up, not a stale claim about a combination
+    that secretly already works."""
+    H_sparse = jax_sparse.BCOO.fromdense(jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]))
+    dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
+    obs_times = jnp.arange(3.0)
+    obs_values = jnp.zeros((3, 2))
+
+    with pytest.warns(UserWarning, match="unlikely to be supported"):
+        with pytest.raises(Exception):
+            with Filter(filter_config=KFConfig(filter_source="cuthbert")):
+                dsx.condition(
+                    "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
+                )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -541,10 +541,11 @@ def test_cuthbert_enkf_sparse_h_matches_dense_h():
     assert jnp.allclose(means_dense, means_sparse)
 
 
-def test_kf_raises_on_sparse_observation_matrix():
-    """KF does not support a sparse H: cuthbert's Kalman internals cannot handle it
-    (vmap's sparse tracing breaks inside a jnp.block call), so dynestyx raises a clear
-    error up front rather than letting that confusing internal failure surface."""
+def test_kf_raises_on_sparse_observation_matrix_cuthbert():
+    """KF's cuthbert backend does not support a sparse H: cuthbert's Kalman internals
+    cannot handle it (vmap's sparse tracing breaks inside a jnp.block call), so dynestyx
+    raises a clear error up front rather than letting that confusing internal failure
+    surface."""
     H_sparse = jax_sparse.BCOO.fromdense(jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]))
     dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
     obs_times = jnp.arange(3.0)
@@ -555,6 +556,54 @@ def test_kf_raises_on_sparse_observation_matrix():
             dsx.condition(
                 "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
             )
+
+
+def test_compute_cuthbert_filter_raises_on_sparse_observation_matrix_direct_call():
+    """The sparse-H check must live at the actual cuthbert entry point
+    (_cuthbert_filter_kalman), not only in Filter: compute_cuthbert_filter is called
+    directly elsewhere (this test file, test_time_varying_linear_gaussian.py, and the
+    cuthbert smoother), bypassing Filter entirely. A direct call must raise the same
+    clear error rather than surfacing a confusing internal AssertionError."""
+    H_sparse = jax_sparse.BCOO.fromdense(jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]))
+    dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
+    obs_times = jnp.arange(3.0)
+    obs_values = jnp.zeros((3, 2))
+
+    with pytest.raises(ValueError, match="not supported"):
+        compute_cuthbert_filter(
+            dynamics_sparse,
+            KFConfig(filter_source="cuthbert"),
+            key=jr.PRNGKey(0),
+            obs_times=obs_times,
+            obs_values=obs_values,
+        )
+
+
+def test_kf_sparse_h_matches_dense_h_cd_dynamax():
+    """Unlike the cuthbert backend, KF's cd_dynamax backend handles a sparse H fine:
+    dynamax's own Kalman update only ever uses H in plain matmuls (H @ P @ H.T, etc.),
+    never mixed into a jnp.block/concatenate call, so there's no sparse-tracing collision.
+    marginal_loglik should match the dense H case exactly (deterministic filter, no CRN
+    needed)."""
+    H_dense = jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    H_sparse = jax_sparse.BCOO.fromdense(H_dense)
+    dynamics_dense = _sparse_h_test_dynamics(H_dense)
+    dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
+    obs_times = jnp.arange(6.0)
+    ground_truth = dsx.simulate(
+        dynamics_dense, rng_key=jr.PRNGKey(0), predict_times=obs_times, n_simulations=1
+    )
+    obs_values = jnp.asarray(ground_truth.observations)[0]
+
+    with Filter(filter_config=KFConfig(filter_source="cd_dynamax")):
+        result_dense = dsx.condition(
+            "f", dynamics_dense, obs_times=obs_times, obs_values=obs_values
+        )
+    with Filter(filter_config=KFConfig(filter_source="cd_dynamax")):
+        result_sparse = dsx.condition(
+            "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
+        )
+    assert jnp.allclose(result_dense.marginal_loglik, result_sparse.marginal_loglik)
 
 
 def test_ekf_warns_on_sparse_observation_matrix_but_still_works():
@@ -577,6 +626,34 @@ def test_ekf_warns_on_sparse_observation_matrix_but_still_works():
         )
     with pytest.warns(UserWarning, match="no efficiency gain"):
         with Filter(filter_config=EKFConfig(filter_source="cuthbert")):
+            result_sparse = dsx.condition(
+                "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
+            )
+    assert jnp.allclose(result_dense.marginal_loglik, result_sparse.marginal_loglik)
+
+
+def test_ekf_warns_on_sparse_observation_matrix_but_still_works_cd_dynamax():
+    """EKF's cd_dynamax backend also works correctly with a sparse H, and also warns of
+    likely no efficiency gain: cd_dynamax's EKF computes H as
+    jax.jacfwd(emission_function), which materializes a dense Jacobian at every step
+    regardless of H's sparsity (same root cause as the cuthbert EKF warning, different
+    mechanism)."""
+    H_dense = jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    H_sparse = jax_sparse.BCOO.fromdense(H_dense)
+    dynamics_dense = _sparse_h_test_dynamics(H_dense)
+    dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
+    obs_times = jnp.arange(6.0)
+    ground_truth = dsx.simulate(
+        dynamics_dense, rng_key=jr.PRNGKey(0), predict_times=obs_times, n_simulations=1
+    )
+    obs_values = jnp.asarray(ground_truth.observations)[0]
+
+    with Filter(filter_config=EKFConfig(filter_source="cd_dynamax")):
+        result_dense = dsx.condition(
+            "f", dynamics_dense, obs_times=obs_times, obs_values=obs_values
+        )
+    with pytest.warns(UserWarning, match="no efficiency gain"):
+        with Filter(filter_config=EKFConfig(filter_source="cd_dynamax")):
             result_sparse = dsx.condition(
                 "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
             )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -541,19 +541,43 @@ def test_cuthbert_enkf_sparse_h_matches_dense_h():
     assert jnp.allclose(means_dense, means_sparse)
 
 
-def test_kf_warns_on_sparse_observation_matrix():
-    """KF is not expected to support a sparse H: the warning should fire, and (since KF
-    itself is not fixed by this change, only EnKF is) it should still go on to fail --
-    confirming the warning is an accurate heads-up, not a stale claim about a combination
-    that secretly already works."""
+def test_kf_raises_on_sparse_observation_matrix():
+    """KF does not support a sparse H: cuthbert's Kalman internals cannot handle it
+    (vmap's sparse tracing breaks inside a jnp.block call), so dynestyx raises a clear
+    error up front rather than letting that confusing internal failure surface."""
     H_sparse = jax_sparse.BCOO.fromdense(jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]))
     dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
     obs_times = jnp.arange(3.0)
     obs_values = jnp.zeros((3, 2))
 
-    with pytest.warns(UserWarning, match="unlikely to be supported"):
-        with pytest.raises(Exception):
-            with Filter(filter_config=KFConfig(filter_source="cuthbert")):
-                dsx.condition(
-                    "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
-                )
+    with pytest.raises(ValueError, match="not supported"):
+        with Filter(filter_config=KFConfig(filter_source="cuthbert")):
+            dsx.condition(
+                "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
+            )
+
+
+def test_ekf_warns_on_sparse_observation_matrix_but_still_works():
+    """EKF works correctly with a sparse H, but the warning should fire to flag that
+    there's likely no efficiency gain (EKF differentiates the log-density directly rather
+    than extracting H, so the underlying computation is dense-scaling regardless)."""
+    H_dense = jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    H_sparse = jax_sparse.BCOO.fromdense(H_dense)
+    dynamics_dense = _sparse_h_test_dynamics(H_dense)
+    dynamics_sparse = _sparse_h_test_dynamics(H_sparse)
+    obs_times = jnp.arange(6.0)
+    ground_truth = dsx.simulate(
+        dynamics_dense, rng_key=jr.PRNGKey(0), predict_times=obs_times, n_simulations=1
+    )
+    obs_values = ground_truth.observations[0]
+
+    with Filter(filter_config=EKFConfig(filter_source="cuthbert")):
+        result_dense = dsx.condition(
+            "f", dynamics_dense, obs_times=obs_times, obs_values=obs_values
+        )
+    with pytest.warns(UserWarning, match="no efficiency gain"):
+        with Filter(filter_config=EKFConfig(filter_source="cuthbert")):
+            result_sparse = dsx.condition(
+                "f", dynamics_sparse, obs_times=obs_times, obs_values=obs_values
+            )
+    assert jnp.allclose(result_dense.marginal_loglik, result_sparse.marginal_loglik)

--- a/tests/test_models_core.py
+++ b/tests/test_models_core.py
@@ -734,7 +734,7 @@ def test_linear_gaussian_observation_callable_fields_match_constant() -> None:
     resolved_D = params.D
     resolved_bias = params.bias
     assert resolved_D is not None and resolved_bias is not None
-    assert jnp.array_equal(params.H, H)
+    assert jnp.array_equal(jnp.asarray(params.H), H)
     assert jnp.array_equal(resolved_D, D)
     assert jnp.array_equal(resolved_bias, bias)
     assert jnp.array_equal(params.R, R)


### PR DESCRIPTION
This PR adds support for sparse observation matrices H from https://docs.jax.dev/en/latest/jax.experimental.sparse.html.

Fairly small changes. 

- PF works as is. 
- EnKF: simply replaced `jnp.dot` with `@` and added a check before `jnp.asarray`.
- EKF: compatible out of the box, but likely no efficiency gains due to autograd. Will raise a warning.
- KF: incompatible due to Cuthbert linalg implementation (unclear if this can be cleanly fixed). Will raise an error.

Added 3 tests to check that computations give the same answers and that warnings/errors are correctly raised.